### PR TITLE
add .gitpod.yml

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+tasks:
+  - command: |
+      cd v1
+      echo $val
+      npm i -g saucectl
+      saucectl run


### PR DESCRIPTION
We want to open saucectl-cypress-example in gitpod, to do that, it has to contain this yml file. See more detail in GRW-1139