### PR TITLE
Bump saucectl-run-action to v2

### DIFF
--- a/.github/workflows/test-v1.yml
+++ b/.github/workflows/test-v1.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Saucectl RUN Docker and Cloud
-        uses: saucelabs/saucectl-run-action@v1
+        uses: saucelabs/saucectl-run-action@v2
         with:
           skip-run: true
           testing-environment: ""
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install saucectl
-        uses: saucelabs/saucectl-run-action@v1
+        uses: saucelabs/saucectl-run-action@v2
         with:
           skip-run: true
           testing-environment: ""
@@ -61,7 +61,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install saucectl
-        uses: saucelabs/saucectl-run-action@v1
+        uses: saucelabs/saucectl-run-action@v2
         with:
           skip-run: true
           testing-environment: ""
@@ -86,7 +86,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install saucectl
-        uses: saucelabs/saucectl-run-action@v1
+        uses: saucelabs/saucectl-run-action@v2
         with:
           skip-run: true
           testing-environment: ""
@@ -110,7 +110,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install saucectl
-        uses: saucelabs/saucectl-run-action@v1
+        uses: saucelabs/saucectl-run-action@v2
         with:
           skip-run: true
           testing-environment: ""

--- a/.github/workflows/test-v1alpha.yml
+++ b/.github/workflows/test-v1alpha.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Saucectl RUN Docker and Cloud
-        uses: saucelabs/saucectl-run-action@v1
+        uses: saucelabs/saucectl-run-action@v2
         with:
           skip-run: true
           testing-environment: ""
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install saucectl
-        uses: saucelabs/saucectl-run-action@v1
+        uses: saucelabs/saucectl-run-action@v2
         with:
           skip-run: true
           testing-environment: ""
@@ -61,7 +61,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install saucectl
-        uses: saucelabs/saucectl-run-action@v1
+        uses: saucelabs/saucectl-run-action@v2
         with:
           skip-run: true
           testing-environment: ""
@@ -86,7 +86,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install saucectl
-        uses: saucelabs/saucectl-run-action@v1
+        uses: saucelabs/saucectl-run-action@v2
         with:
           skip-run: true
           testing-environment: ""
@@ -110,7 +110,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install saucectl
-        uses: saucelabs/saucectl-run-action@v1
+        uses: saucelabs/saucectl-run-action@v2
         with:
           skip-run: true
           testing-environment: ""

--- a/v1/.sauce/config.yml
+++ b/v1/.sauce/config.yml
@@ -48,6 +48,7 @@ suites:
   - name: "Firefox on Mac"
     mode: sauce
     browser: "firefox"
+    browserVersion: "104"
     shard: spec
     platformName: "macOS 12"
     config:

--- a/v1/examples/cypress-grep/.sauce/config.yml
+++ b/v1/examples/cypress-grep/.sauce/config.yml
@@ -30,6 +30,7 @@ suites:
   - name: "Firefox on Mac"
     mode: sauce
     browser: "firefox"
+    browserVersion: "104"
     platformName: "macOS 12"
     config:
       specPattern: [ "cypress/e2e/**/*.*" ]

--- a/v1alpha/.sauce/config.yml
+++ b/v1alpha/.sauce/config.yml
@@ -48,6 +48,7 @@ suites:
   - name: "Firefox on Mac"
     mode: sauce
     browser: "firefox"
+    browserVersion: "104"
     shard: spec
     platformName: "macOS 12"
     config:


### PR DESCRIPTION
Mainly for validating the newest release of https://github.com/saucelabs/saucectl-run-action