### PR TITLE
add result and container jsons to artifacts download on allure example

### DIFF
--- a/v1alpha/examples/allure-plugin/.sauce/config.yml
+++ b/v1alpha/examples/allure-plugin/.sauce/config.yml
@@ -38,6 +38,9 @@ artifacts:
     when: always
     match:
       - console.log
+      - '*-result.json'
+      - '*-container.json'
+
     directory: ./artifacts/
 
 # https://docs.saucelabs.com/web-apps/automated-testing/cypress/yaml/#npm


### PR DESCRIPTION
Adding the result and container JSON files to the files downloaded as artifacts makes this a more realistic example as a customer would want to download these to then move to an allure-results folder for consumption.