### PR TITLE
chore: Bump to latest supported framework version

### DIFF
--- a/v1/.sauce/config.yml
+++ b/v1/.sauce/config.yml
@@ -10,7 +10,7 @@ sauce:
       - other tag
     build: Github Run $GITHUB_RUN_ID
 cypress:
-  version: 13.6.6 # See https://docs.saucelabs.com/web-apps/automated-testing/cypress/#supported-testing-platforms for a list of supported versions.
+  version: 13.7.3 # See https://docs.saucelabs.com/web-apps/automated-testing/cypress/#supported-testing-platforms for a list of supported versions.
   configFile: "cypress.config.js"
 
 #   reporters:

--- a/v1/examples/allure-plugin/.sauce/config.yml
+++ b/v1/examples/allure-plugin/.sauce/config.yml
@@ -10,7 +10,7 @@ sauce:
       - other tag
     build: Github Run $GITHUB_RUN_ID
 cypress:
-  version: 13.6.6 # See https://docs.saucelabs.com/web-apps/automated-testing/cypress/#supported-testing-platforms for a list of supported versions.
+  version: 13.7.3 # See https://docs.saucelabs.com/web-apps/automated-testing/cypress/#supported-testing-platforms for a list of supported versions.
   configFile: "cypress.config.js"
 
 # Controls what files are available in the context of a test run (unless explicitly excluded by .sauceignore).

--- a/v1/examples/cucumber/.sauce/config.yml
+++ b/v1/examples/cucumber/.sauce/config.yml
@@ -10,7 +10,7 @@ sauce:
       - example repo
     # build: Github Run $GITHUB_RUN_ID
 cypress:
-  version: 13.6.6 # See https://docs.saucelabs.com/web-apps/automated-testing/cypress/#supported-testing-platforms for a list of supported versions.
+  version: 13.7.3 # See https://docs.saucelabs.com/web-apps/automated-testing/cypress/#supported-testing-platforms for a list of supported versions.
   configFile: "cypress.config.js"  # We determine related files based on the location of the config file.
 # Controls what files are available in the context of a test run (unless explicitly excluded by .sauceignore).
 rootDir: ./

--- a/v1/examples/cypress-grep/.sauce/config.yml
+++ b/v1/examples/cypress-grep/.sauce/config.yml
@@ -9,7 +9,7 @@ sauce:
       - cypress-grep-example
     build: Github Run $GITHUB_RUN_ID
 cypress:
-  version: 13.6.6
+  version: 13.7.3
   configFile: "cypress.config.js"
 rootDir: ./
 suites:

--- a/v1/examples/typescript/.sauce/config.yml
+++ b/v1/examples/typescript/.sauce/config.yml
@@ -10,7 +10,7 @@ sauce:
       - other tag
     build: Github Run $GITHUB_RUN_ID
 cypress:
-  version: 13.6.6 # See https://docs.saucelabs.com/web-apps/automated-testing/cypress/#supported-testing-platforms for a list of supported versions.
+  version: 13.7.3 # See https://docs.saucelabs.com/web-apps/automated-testing/cypress/#supported-testing-platforms for a list of supported versions.
   configFile: "cypress.config.js"
 # Controls what files are available in the context of a test run (unless explicitly excluded by .sauceignore).
 rootDir: ./

--- a/v1/examples/webkit/.sauce/config.yml
+++ b/v1/examples/webkit/.sauce/config.yml
@@ -9,7 +9,7 @@ sauce:
       - cypress-example
 
 cypress:
-  version: 13.6.6
+  version: 13.7.3
   configFile: "cypress.config.js"
 
 rootDir: ./


### PR DESCRIPTION
Update examples to target latest cypress version.

[DEVX-2836]

[DEVX-2836]: https://saucedev.atlassian.net/browse/DEVX-2836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ