### PR TITLE
Bump to cypress@15.12.0

### DIFF
--- a/v1/.sauce/config.yml
+++ b/v1/.sauce/config.yml
@@ -10,7 +10,7 @@ sauce:
       - other tag
     build: Github Run $GITHUB_RUN_ID
 cypress:
-  version: 15.9.0 # See https://docs.saucelabs.com/web-apps/automated-testing/cypress/#supported-testing-platforms for a list of supported versions.
+  version: 15.12.0 # See https://docs.saucelabs.com/web-apps/automated-testing/cypress/#supported-testing-platforms for a list of supported versions.
   configFile: "cypress.config.js"
 
 # Controls what files are available in the context of a test run (unless explicitly excluded by .sauceignore).

--- a/v1/examples/allure-plugin/.sauce/config.yml
+++ b/v1/examples/allure-plugin/.sauce/config.yml
@@ -10,7 +10,7 @@ sauce:
       - other tag
     build: Github Run $GITHUB_RUN_ID
 cypress:
-  version: 15.9.0 # See https://docs.saucelabs.com/web-apps/automated-testing/cypress/#supported-testing-platforms for a list of supported versions.
+  version: 15.12.0 # See https://docs.saucelabs.com/web-apps/automated-testing/cypress/#supported-testing-platforms for a list of supported versions.
   configFile: "cypress.config.js"
 
 # Controls what files are available in the context of a test run (unless explicitly excluded by .sauceignore).

--- a/v1/examples/component-testing-react-vite-ts/.sauce/config.yml
+++ b/v1/examples/component-testing-react-vite-ts/.sauce/config.yml
@@ -7,7 +7,7 @@ sauce:
     tags:
       - cypress-example
 cypress:
-  version: 15.9.0 # See https://docs.saucelabs.com/web-apps/automated-testing/cypress/#supported-testing-platforms for a list of supported versions.
+  version: 15.12.0 # See https://docs.saucelabs.com/web-apps/automated-testing/cypress/#supported-testing-platforms for a list of supported versions.
   configFile: "cypress.config.ts"
 
 # Controls what files are available in the context of a test run (unless explicitly excluded by .sauceignore).

--- a/v1/examples/component-testing-react-vite-ts/package-lock.json
+++ b/v1/examples/component-testing-react-vite-ts/package-lock.json
@@ -17,7 +17,7 @@
                 "@types/react-dom": "^19.0.0",
                 "@vitejs/plugin-react": "^4.3.4",
                 "autoprefixer": "^10.4.20",
-                "cypress": "15.9.0",
+                "cypress": "15.12.0",
                 "postcss": "^8.4.47",
                 "tailwindcss": "^3.4.14",
                 "typescript": "^5.6.3",
@@ -68,7 +68,6 @@
             "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.28.6",
                 "@babel/generator": "^7.28.6",
@@ -1464,7 +1463,6 @@
             "integrity": "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==",
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "undici-types": "~7.16.0"
             }
@@ -1475,7 +1473,6 @@
             "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
@@ -1877,7 +1874,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -2301,9 +2297,9 @@
             "license": "MIT"
         },
         "node_modules/cypress": {
-            "version": "15.9.0",
-            "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.9.0.tgz",
-            "integrity": "sha512-Ks6Bdilz3TtkLZtTQyqYaqtL/WT3X3APKaSLhTV96TmTyudzSjc6EJsJCHmBb7DxO+3R12q3Jkbjgm/iPgmwfg==",
+            "version": "15.12.0",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/cypress/-/cypress-15.12.0.tgz",
+            "integrity": "sha512-B2BRcudLfA4NZZP5QpA45J70bu1heCH59V1yKRLHAtiC49r7RV03X5ifUh7Nfbk8QNg93RAsc6oAmodm/+j0pA==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -2336,7 +2332,7 @@
                 "hasha": "5.2.2",
                 "is-installed-globally": "~0.4.0",
                 "listr2": "^3.8.3",
-                "lodash": "^4.17.21",
+                "lodash": "^4.17.23",
                 "log-symbols": "^4.0.0",
                 "minimist": "^1.2.8",
                 "ospath": "^1.2.2",
@@ -2345,9 +2341,10 @@
                 "proxy-from-env": "1.0.0",
                 "request-progress": "^3.0.0",
                 "supports-color": "^8.1.1",
-                "systeminformation": "^5.27.14",
+                "systeminformation": "^5.31.1",
                 "tmp": "~0.2.4",
                 "tree-kill": "1.2.2",
+                "tslib": "1.14.1",
                 "untildify": "^4.0.0",
                 "yauzl": "^2.10.0"
             },
@@ -2357,6 +2354,13 @@
             "engines": {
                 "node": "^20.1.0 || ^22.0.0 || >=24.0.0"
             }
+        },
+        "node_modules/cypress/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true,
+            "license": "0BSD"
         },
         "node_modules/dashdash": {
             "version": "1.14.1",
@@ -2475,7 +2479,6 @@
             "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-colors": "^4.1.1",
                 "strip-ansi": "^6.0.1"
@@ -3277,7 +3280,6 @@
             "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "jiti": "bin/jiti.js"
             }
@@ -3940,7 +3942,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -4167,7 +4168,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
             "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -4689,9 +4689,9 @@
             }
         },
         "node_modules/systeminformation": {
-            "version": "5.30.6",
-            "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.30.6.tgz",
-            "integrity": "sha512-LEIyK1aEv5P3BhAPW3swdlIyCihxwEq/Gki+kcONieU4PIeRCSLDuGkk0Va/56PSBgjVgEksOM88dmY6YqOyfQ==",
+            "version": "5.31.5",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/systeminformation/-/systeminformation-5.31.5.tgz",
+            "integrity": "sha512-5SyLdip4/3alxD4Kh+63bUQTJmu7YMfYQTC+koZy7X73HgNqZSD2P4wOZQWtUncvPvcEmnfIjCoygN4MRoEejQ==",
             "dev": true,
             "license": "MIT",
             "os": [
@@ -4846,7 +4846,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -4970,7 +4969,6 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "devOptional": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -5084,7 +5082,6 @@
             "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.4.4",
@@ -5178,7 +5175,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },

--- a/v1/examples/component-testing-react-vite-ts/package.json
+++ b/v1/examples/component-testing-react-vite-ts/package.json
@@ -18,7 +18,7 @@
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.3.4",
         "autoprefixer": "^10.4.20",
-        "cypress": "15.9.0",
+        "cypress": "15.12.0",
         "postcss": "^8.4.47",
         "tailwindcss": "^3.4.14",
         "typescript": "^5.6.3",

--- a/v1/examples/cucumber/.sauce/config.yml
+++ b/v1/examples/cucumber/.sauce/config.yml
@@ -10,7 +10,7 @@ sauce:
       - example repo
     # build: Github Run $GITHUB_RUN_ID
 cypress:
-  version: 15.9.0 # See https://docs.saucelabs.com/web-apps/automated-testing/cypress/#supported-testing-platforms for a list of supported versions.
+  version: 15.12.0 # See https://docs.saucelabs.com/web-apps/automated-testing/cypress/#supported-testing-platforms for a list of supported versions.
   configFile: "cypress.config.js" # We determine related files based on the location of the config file.
 # Controls what files are available in the context of a test run (unless explicitly excluded by .sauceignore).
 rootDir: ./

--- a/v1/examples/cucumber/package-lock.json
+++ b/v1/examples/cucumber/package-lock.json
@@ -5,16 +5,16 @@
     "packages": {
         "": {
             "dependencies": {
-                "@badeball/cypress-cucumber-preprocessor": "24.0.0",
+                "@badeball/cypress-cucumber-preprocessor": "24.0.1",
                 "@bahmutov/cypress-esbuild-preprocessor": "2.2.3",
                 "@shelex/cypress-allure-plugin": "^2.40.2",
-                "cypress": "15.9.0",
+                "cypress": "15.12.0",
                 "esbuild": "0.24.0"
             }
         },
         "node_modules/@actions/core": {
             "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@actions/core/-/core-2.0.3.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@actions/core/-/core-2.0.3.tgz",
             "integrity": "sha512-Od9Thc3T1mQJYddvVPM4QGiLUewdh+3txmDYHHxoNdkqysR1MbCT+rFOtNUxYAz+7+6RIsqipVahY2GJqGPyxA==",
             "license": "MIT",
             "dependencies": {
@@ -24,7 +24,7 @@
         },
         "node_modules/@actions/exec": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-2.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@actions/exec/-/exec-2.0.0.tgz",
             "integrity": "sha512-k8ngrX2voJ/RIN6r9xB82NVqKpnMRtxDoiO+g3olkIUpQNqjArXrCQceduQZCQj3P3xm32pChRLqRrtXTlqhIw==",
             "license": "MIT",
             "dependencies": {
@@ -33,7 +33,7 @@
         },
         "node_modules/@actions/http-client": {
             "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-3.0.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@actions/http-client/-/http-client-3.0.2.tgz",
             "integrity": "sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA==",
             "license": "MIT",
             "dependencies": {
@@ -43,14 +43,14 @@
         },
         "node_modules/@actions/io": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@actions/io/-/io-2.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@actions/io/-/io-2.0.0.tgz",
             "integrity": "sha512-Jv33IN09XLO+0HS79aaODsvIRyduiF7NY/F6LYeK5oeUmrsz7aFdRphQjFoESF4jS7lMauDOttKALcpapVDIAg==",
             "license": "MIT"
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.28.6.tgz",
-            "integrity": "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==",
+            "version": "7.29.0",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@babel/code-frame/-/code-frame-7.29.0.tgz",
+            "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.28.5",
@@ -62,30 +62,31 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.6.tgz",
-            "integrity": "sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==",
+            "version": "7.29.0",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@babel/compat-data/-/compat-data-7.29.0.tgz",
+            "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.6.tgz",
-            "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
+            "version": "7.29.0",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@babel/core/-/core-7.29.0.tgz",
+            "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/code-frame": "^7.28.6",
-                "@babel/generator": "^7.28.6",
+                "@babel/code-frame": "^7.29.0",
+                "@babel/generator": "^7.29.0",
                 "@babel/helper-compilation-targets": "^7.28.6",
                 "@babel/helper-module-transforms": "^7.28.6",
                 "@babel/helpers": "^7.28.6",
-                "@babel/parser": "^7.28.6",
+                "@babel/parser": "^7.29.0",
                 "@babel/template": "^7.28.6",
-                "@babel/traverse": "^7.28.6",
-                "@babel/types": "^7.28.6",
+                "@babel/traverse": "^7.29.0",
+                "@babel/types": "^7.29.0",
                 "@jridgewell/remapping": "^2.3.5",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
@@ -103,21 +104,23 @@
         },
         "node_modules/@babel/core/node_modules/semver": {
             "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.6.tgz",
-            "integrity": "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw==",
+            "version": "7.29.1",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@babel/generator/-/generator-7.29.1.tgz",
+            "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "@babel/parser": "^7.28.6",
-                "@babel/types": "^7.28.6",
+                "@babel/parser": "^7.29.0",
+                "@babel/types": "^7.29.0",
                 "@jridgewell/gen-mapping": "^0.3.12",
                 "@jridgewell/trace-mapping": "^0.3.28",
                 "jsesc": "^3.0.2"
@@ -128,9 +131,10 @@
         },
         "node_modules/@babel/helper-compilation-targets": {
             "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
             "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/compat-data": "^7.28.6",
                 "@babel/helper-validator-option": "^7.27.1",
@@ -144,27 +148,30 @@
         },
         "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
             "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
         },
         "node_modules/@babel/helper-globals": {
             "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
             "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-imports": {
             "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
             "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/traverse": "^7.28.6",
                 "@babel/types": "^7.28.6"
@@ -175,9 +182,10 @@
         },
         "node_modules/@babel/helper-module-transforms": {
             "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
             "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.28.6",
                 "@babel/helper-validator-identifier": "^7.28.5",
@@ -192,7 +200,7 @@
         },
         "node_modules/@babel/helper-plugin-utils": {
             "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
             "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
             "license": "MIT",
             "engines": {
@@ -201,7 +209,7 @@
         },
         "node_modules/@babel/helper-string-parser": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
             "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
             "license": "MIT",
             "engines": {
@@ -210,7 +218,7 @@
         },
         "node_modules/@babel/helper-validator-identifier": {
             "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
             "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
             "license": "MIT",
             "engines": {
@@ -219,33 +227,35 @@
         },
         "node_modules/@babel/helper-validator-option": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
             "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-            "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+            "version": "7.29.2",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@babel/helpers/-/helpers-7.29.2.tgz",
+            "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/template": "^7.28.6",
-                "@babel/types": "^7.28.6"
+                "@babel/types": "^7.29.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.6.tgz",
-            "integrity": "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==",
+            "version": "7.29.2",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@babel/parser/-/parser-7.29.2.tgz",
+            "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.28.6"
+                "@babel/types": "^7.29.0"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -256,7 +266,7 @@
         },
         "node_modules/@babel/plugin-syntax-jsx": {
             "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
             "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
             "license": "MIT",
             "dependencies": {
@@ -271,9 +281,10 @@
         },
         "node_modules/@babel/template": {
             "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@babel/template/-/template-7.28.6.tgz",
             "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.28.6",
                 "@babel/parser": "^7.28.6",
@@ -284,17 +295,18 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.6.tgz",
-            "integrity": "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg==",
+            "version": "7.29.0",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@babel/traverse/-/traverse-7.29.0.tgz",
+            "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "@babel/code-frame": "^7.28.6",
-                "@babel/generator": "^7.28.6",
+                "@babel/code-frame": "^7.29.0",
+                "@babel/generator": "^7.29.0",
                 "@babel/helper-globals": "^7.28.0",
-                "@babel/parser": "^7.28.6",
+                "@babel/parser": "^7.29.0",
                 "@babel/template": "^7.28.6",
-                "@babel/types": "^7.28.6",
+                "@babel/types": "^7.29.0",
                 "debug": "^4.3.1"
             },
             "engines": {
@@ -302,9 +314,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.6.tgz",
-            "integrity": "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==",
+            "version": "7.29.0",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@babel/types/-/types-7.29.0.tgz",
+            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.27.1",
@@ -315,9 +327,9 @@
             }
         },
         "node_modules/@badeball/cypress-cucumber-preprocessor": {
-            "version": "24.0.0",
-            "resolved": "https://registry.npmjs.org/@badeball/cypress-cucumber-preprocessor/-/cypress-cucumber-preprocessor-24.0.0.tgz",
-            "integrity": "sha512-WjmmnjkN49E52vp65TldsbiP3WtgTp7JQDZal8qNCHpnjmGjBW70JjIUL4/RfvxujZIUDx13W/VFiPTlG0FhRw==",
+            "version": "24.0.1",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@badeball/cypress-cucumber-preprocessor/-/cypress-cucumber-preprocessor-24.0.1.tgz",
+            "integrity": "sha512-pZl/sMXbOHihStjCEDrO5cQbcxJw8QteHGamPg+fAjkg2M6PHYqu7aGToK9P2D4lBP0ChoMIFM2/kbysQRmJyw==",
             "funding": [
                 {
                     "type": "github",
@@ -326,18 +338,17 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@cucumber/ci-environment": "^12.0.0",
+                "@cucumber/ci-environment": "^13.0.0",
                 "@cucumber/cucumber": "^12.0.0",
-                "@cucumber/cucumber-expressions": "^18.0.0",
-                "@cucumber/gherkin": "^37.0.0",
-                "@cucumber/html-formatter": "^22.2.0",
+                "@cucumber/cucumber-expressions": "^19.0.0",
+                "@cucumber/gherkin": "^38.0.0",
+                "@cucumber/html-formatter": "^23.0.0",
                 "@cucumber/message-streams": "^4.0.1",
-                "@cucumber/messages": "^31.0.0",
-                "@cucumber/pretty-formatter": "^1.0.1",
-                "@cucumber/tag-expressions": "^8.0.0",
+                "@cucumber/messages": "^32.0.0",
+                "@cucumber/pretty-formatter": "^3.0.0",
+                "@cucumber/tag-expressions": "^9.0.0",
                 "@jridgewell/trace-mapping": "^0.3.31",
                 "base64-js": "^1.5.1",
-                "chalk": "^4.1.2",
                 "cli-table": "^0.3.11",
                 "common-ancestor-path": "^2.0.0",
                 "cosmiconfig": "^9.0.0",
@@ -366,7 +377,7 @@
         },
         "node_modules/@bahmutov/cypress-esbuild-preprocessor": {
             "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/@bahmutov/cypress-esbuild-preprocessor/-/cypress-esbuild-preprocessor-2.2.3.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@bahmutov/cypress-esbuild-preprocessor/-/cypress-esbuild-preprocessor-2.2.3.tgz",
             "integrity": "sha512-YdrZxCULKC3k5H5bjBeL6boadcsSXsdnJf6GQGHMRcqzUFzDQC1sZGNblauJzUU34XbA4Sko5ym4KajKf4WwAw==",
             "license": "MIT",
             "dependencies": {
@@ -378,7 +389,7 @@
         },
         "node_modules/@bahmutov/cypress-esbuild-preprocessor/node_modules/debug": {
             "version": "4.3.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/debug/-/debug-4.3.7.tgz",
             "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
             "license": "MIT",
             "dependencies": {
@@ -395,7 +406,7 @@
         },
         "node_modules/@colors/colors": {
             "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@colors/colors/-/colors-1.5.0.tgz",
             "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
             "license": "MIT",
             "optional": true,
@@ -404,29 +415,28 @@
             }
         },
         "node_modules/@cucumber/ci-environment": {
-            "version": "12.0.0",
-            "resolved": "https://registry.npmjs.org/@cucumber/ci-environment/-/ci-environment-12.0.0.tgz",
-            "integrity": "sha512-SqCEnbCNl3zCXCFpqGUuoaSNhLC0jLw4tKeFcAxTw9MD/QRlJjeAC/fyvVLFuXuSq0OunJlFfxLu+Z3HE+oLPg==",
+            "version": "13.0.0",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@cucumber/ci-environment/-/ci-environment-13.0.0.tgz",
+            "integrity": "sha512-cs+3NzfNkGbcmHPddjEv4TKFiBpZRQ6WJEEufB9mw+ExS22V/4R/zpDSEG+fsJ/iSNCd6A2sATdY8PFOyY3YnA==",
             "license": "MIT"
         },
         "node_modules/@cucumber/cucumber": {
-            "version": "12.6.0",
-            "resolved": "https://registry.npmjs.org/@cucumber/cucumber/-/cucumber-12.6.0.tgz",
-            "integrity": "sha512-z6XKBIcUnJebnR3W8+K7Q2jJKB+pKpoD1l3CygEa9ufq/aeGuS5LAlllNxrod8loepLJhNmp8J8aengGbkL4cg==",
+            "version": "12.7.0",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@cucumber/cucumber/-/cucumber-12.7.0.tgz",
+            "integrity": "sha512-7A/9CJpJDxv1SQ7hAZU0zPn2yRxx6XMR+LO4T94Enm3cYNWsEEj+RGX38NLX4INT+H6w5raX3Csb/qs4vUBsOA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
-                "@cucumber/ci-environment": "12.0.0",
-                "@cucumber/cucumber-expressions": "18.1.0",
-                "@cucumber/gherkin": "37.0.1",
+                "@cucumber/ci-environment": "13.0.0",
+                "@cucumber/cucumber-expressions": "19.0.0",
+                "@cucumber/gherkin": "38.0.0",
                 "@cucumber/gherkin-streams": "6.0.0",
-                "@cucumber/gherkin-utils": "10.0.0",
-                "@cucumber/html-formatter": "22.3.0",
+                "@cucumber/gherkin-utils": "11.0.0",
+                "@cucumber/html-formatter": "23.0.0",
                 "@cucumber/junit-xml-formatter": "0.9.0",
                 "@cucumber/message-streams": "4.0.1",
-                "@cucumber/messages": "31.2.0",
+                "@cucumber/messages": "32.0.1",
                 "@cucumber/pretty-formatter": "1.0.1",
-                "@cucumber/tag-expressions": "8.1.0",
+                "@cucumber/tag-expressions": "9.1.0",
                 "assertion-error-formatter": "^3.0.0",
                 "capital-case": "^1.0.4",
                 "chalk": "^4.1.2",
@@ -449,7 +459,7 @@
                 "mz": "^2.7.0",
                 "progress": "^2.0.3",
                 "read-package-up": "^12.0.0",
-                "semver": "7.7.3",
+                "semver": "7.7.4",
                 "string-argv": "0.3.1",
                 "supports-color": "^8.1.1",
                 "type-fest": "^4.41.0",
@@ -468,27 +478,64 @@
             }
         },
         "node_modules/@cucumber/cucumber-expressions": {
-            "version": "18.1.0",
-            "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-18.1.0.tgz",
-            "integrity": "sha512-9yc+wForrn15FaqLWNjYb19iQ/gPXhcq1kc4X1Ex1lR7NcJpa5pGnCow3bc1HERVM5IoYH+gwwrcJogSMsf+Vw==",
+            "version": "19.0.0",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@cucumber/cucumber-expressions/-/cucumber-expressions-19.0.0.tgz",
+            "integrity": "sha512-4FKoOQh2Uf6F6/Ln+1OxuK8LkTg6PyAqekhf2Ix8zqV2M54sH+m7XNJNLhOFOAW/t9nxzRbw2CcvXbCLjcvHZg==",
             "license": "MIT",
             "dependencies": {
                 "regexp-match-indices": "1.0.2"
             }
         },
-        "node_modules/@cucumber/gherkin": {
-            "version": "37.0.1",
-            "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-37.0.1.tgz",
-            "integrity": "sha512-VmX+PKa9vqKZiycZoQKYlCsA0N7gAfiOfrcHSjK+suEVUwvKEH2sjO47NznrFFLmVWYTRmw3DLHQnpBAznkYEA==",
+        "node_modules/@cucumber/cucumber/node_modules/@cucumber/messages": {
+            "version": "32.0.1",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@cucumber/messages/-/messages-32.0.1.tgz",
+            "integrity": "sha512-1OSoW+GQvFUNAl6tdP2CTBexTXMNJF0094goVUcvugtQeXtJ0K8sCP0xbq7GGoiezs/eJAAOD03+zAPT64orHQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
-                "@cucumber/messages": ">=31.0.0 <32"
+                "class-transformer": "0.5.1",
+                "reflect-metadata": "0.2.2"
+            }
+        },
+        "node_modules/@cucumber/cucumber/node_modules/@cucumber/pretty-formatter": {
+            "version": "1.0.1",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@cucumber/pretty-formatter/-/pretty-formatter-1.0.1.tgz",
+            "integrity": "sha512-A1lU4VVP0aUWdOTmpdzvXOyEYuPtBDI0xYwYJnmoMDplzxMdhcHk86lyyvYDoMoPzzq6OkOE3isuosvUU4X7IQ==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^5.0.0",
+                "cli-table3": "^0.6.0",
+                "figures": "^3.2.0",
+                "ts-dedent": "^2.0.0"
+            },
+            "peerDependencies": {
+                "@cucumber/cucumber": ">=7.0.0",
+                "@cucumber/messages": "*"
+            }
+        },
+        "node_modules/@cucumber/cucumber/node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@cucumber/gherkin": {
+            "version": "38.0.0",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@cucumber/gherkin/-/gherkin-38.0.0.tgz",
+            "integrity": "sha512-duEXK+KDfQUzu3vsSzXjkxQ2tirF5PRsc1Xrts6THKHJO6mjw4RjM8RV+vliuDasmhhrmdLcOcM7d9nurNTJKw==",
+            "license": "MIT",
+            "dependencies": {
+                "@cucumber/messages": ">=31.0.0 <33"
             }
         },
         "node_modules/@cucumber/gherkin-streams": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/@cucumber/gherkin-streams/-/gherkin-streams-6.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@cucumber/gherkin-streams/-/gherkin-streams-6.0.0.tgz",
             "integrity": "sha512-HLSHMmdDH0vCr7vsVEURcDA4WwnRLdjkhqr6a4HQ3i4RFK1wiDGPjBGVdGJLyuXuRdJpJbFc6QxHvT8pU4t6jw==",
             "license": "MIT",
             "dependencies": {
@@ -506,7 +553,7 @@
         },
         "node_modules/@cucumber/gherkin-streams/node_modules/commander": {
             "version": "14.0.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/commander/-/commander-14.0.0.tgz",
             "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
             "license": "MIT",
             "engines": {
@@ -514,78 +561,34 @@
             }
         },
         "node_modules/@cucumber/gherkin-utils": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/@cucumber/gherkin-utils/-/gherkin-utils-10.0.0.tgz",
-            "integrity": "sha512-BcujlDT343GXXNrMPl3ws6Il3zs8dQw3Yp/d3HnOJF8i2snGGgiapoTbko7MdvAt7ivDL7SDo+e1d5Cnpl3llA==",
+            "version": "11.0.0",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@cucumber/gherkin-utils/-/gherkin-utils-11.0.0.tgz",
+            "integrity": "sha512-LJ+s4+TepHTgdKWDR4zbPyT7rQjmYIcukTwNbwNwgqr6i8Gjcmzf6NmtbYDA19m1ZFg6kWbFsmHnj37ZuX+kZA==",
             "license": "MIT",
             "dependencies": {
-                "@cucumber/gherkin": "^34.0.0",
-                "@cucumber/messages": "^29.0.0",
+                "@cucumber/gherkin": "^38.0.0",
+                "@cucumber/messages": "^32.0.0",
                 "@teppeis/multimaps": "3.0.0",
-                "commander": "14.0.0",
+                "commander": "14.0.2",
                 "source-map-support": "^0.5.21"
             },
             "bin": {
                 "gherkin-utils": "bin/gherkin-utils"
             }
         },
-        "node_modules/@cucumber/gherkin-utils/node_modules/@cucumber/gherkin": {
-            "version": "34.0.0",
-            "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-34.0.0.tgz",
-            "integrity": "sha512-659CCFsrsyvuBi/Eix1fnhSheMnojSfnBcqJ3IMPNawx7JlrNJDcXYSSdxcUw3n/nG05P+ptCjmiZY3i14p+tA==",
-            "license": "MIT",
-            "dependencies": {
-                "@cucumber/messages": ">=19.1.4 <29"
-            }
-        },
-        "node_modules/@cucumber/gherkin-utils/node_modules/@cucumber/gherkin/node_modules/@cucumber/messages": {
-            "version": "28.1.0",
-            "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-28.1.0.tgz",
-            "integrity": "sha512-2LzZtOwYKNlCuNf31ajkrekoy2M4z0Z1QGiPH40n4gf5t8VOUFb7m1ojtR4LmGvZxBGvJZP8voOmRqDWzBzYKA==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/uuid": "10.0.0",
-                "class-transformer": "0.5.1",
-                "reflect-metadata": "0.2.2",
-                "uuid": "11.1.0"
-            }
-        },
-        "node_modules/@cucumber/gherkin-utils/node_modules/@cucumber/messages": {
-            "version": "29.0.1",
-            "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-29.0.1.tgz",
-            "integrity": "sha512-aAvIYfQD6/aBdF8KFQChC3CQ1Q+GX9orlR6GurGiX6oqaCnBkxA4WU3OQUVepDynEFrPayerqKRFcAMhdcXReQ==",
-            "license": "MIT",
-            "dependencies": {
-                "class-transformer": "0.5.1",
-                "reflect-metadata": "0.2.2"
-            }
-        },
         "node_modules/@cucumber/gherkin-utils/node_modules/commander": {
-            "version": "14.0.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
-            "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
+            "version": "14.0.2",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/commander/-/commander-14.0.2.tgz",
+            "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=20"
             }
         },
-        "node_modules/@cucumber/gherkin-utils/node_modules/uuid": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-            "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/esm/bin/uuid"
-            }
-        },
         "node_modules/@cucumber/html-formatter": {
-            "version": "22.3.0",
-            "resolved": "https://registry.npmjs.org/@cucumber/html-formatter/-/html-formatter-22.3.0.tgz",
-            "integrity": "sha512-0s3G7kznCRDiiesQ4K0yBdswGqU9E0j2AWUug41NpedBzhaY+Hn192ANRF597GZtuWrCjE53aFb3fOyOsT8B+g==",
+            "version": "23.0.0",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@cucumber/html-formatter/-/html-formatter-23.0.0.tgz",
+            "integrity": "sha512-WwcRzdM8Ixy4e53j+Frm3fKM5rNuIyWUfy4HajEN+Xk/YcjA6yW0ACGTFDReB++VDZz/iUtwYdTlPRY36NbqJg==",
             "license": "MIT",
             "peerDependencies": {
                 "@cucumber/messages": ">=18"
@@ -593,7 +596,7 @@
         },
         "node_modules/@cucumber/junit-xml-formatter": {
             "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/@cucumber/junit-xml-formatter/-/junit-xml-formatter-0.9.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@cucumber/junit-xml-formatter/-/junit-xml-formatter-0.9.0.tgz",
             "integrity": "sha512-WF+A7pBaXpKMD1i7K59Nk5519zj4extxY4+4nSgv5XLsGXHDf1gJnb84BkLUzevNtp2o2QzMG0vWLwSm8V5blw==",
             "license": "MIT",
             "dependencies": {
@@ -608,44 +611,52 @@
         },
         "node_modules/@cucumber/message-streams": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@cucumber/message-streams/-/message-streams-4.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@cucumber/message-streams/-/message-streams-4.0.1.tgz",
             "integrity": "sha512-Kxap9uP5jD8tHUZVjTWgzxemi/0uOsbGjd4LBOSxcJoOCRbESFwemUzilJuzNTB8pcTQUh8D5oudUyxfkJOKmA==",
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "@cucumber/messages": ">=17.1.1"
             }
         },
         "node_modules/@cucumber/messages": {
-            "version": "31.2.0",
-            "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-31.2.0.tgz",
-            "integrity": "sha512-3urzBNCwmU/YKrKR0b3XdioFcOFNuxlLwEImsxeP8rXnweLs+Ky04QURcbKpFom3T6a6v9zVioLCfHUuSQ72pg==",
+            "version": "32.2.0",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@cucumber/messages/-/messages-32.2.0.tgz",
+            "integrity": "sha512-oYp1dgL2TByYWL51Z+rNm+/mFtJhiPU9WS03goes9EALb8d9GFcXRbG1JluFLFaChF1YDqIzLac0kkC3tv1DjQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "class-transformer": "0.5.1",
                 "reflect-metadata": "0.2.2"
             }
         },
         "node_modules/@cucumber/pretty-formatter": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@cucumber/pretty-formatter/-/pretty-formatter-1.0.1.tgz",
-            "integrity": "sha512-A1lU4VVP0aUWdOTmpdzvXOyEYuPtBDI0xYwYJnmoMDplzxMdhcHk86lyyvYDoMoPzzq6OkOE3isuosvUU4X7IQ==",
+            "version": "3.2.0",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@cucumber/pretty-formatter/-/pretty-formatter-3.2.0.tgz",
+            "integrity": "sha512-QN+UwKHMGs/PwDCu/CU6Q9F89SvMgS2Gh9GU05CFNDE/asJjhCYdh0IksfFZfwPcbJ/3WxcqXLuNzUws0npPgw==",
             "license": "MIT",
             "dependencies": {
-                "ansi-styles": "^5.0.0",
-                "cli-table3": "^0.6.0",
-                "figures": "^3.2.0",
-                "ts-dedent": "^2.0.0"
+                "@cucumber/query": "15.0.1",
+                "luxon": "^3.7.2"
             },
             "peerDependencies": {
-                "@cucumber/cucumber": ">=7.0.0",
+                "@cucumber/messages": "*"
+            }
+        },
+        "node_modules/@cucumber/pretty-formatter/node_modules/@cucumber/query": {
+            "version": "15.0.1",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@cucumber/query/-/query-15.0.1.tgz",
+            "integrity": "sha512-FMfT3orJblRsOxvU2doECBvQmauizYlj+5JsM8atAKKPbnQTj7v2/OrnuykvQpfZNBf19DYbRq1e832vllRP/g==",
+            "license": "MIT",
+            "dependencies": {
+                "@teppeis/multimaps": "3.0.0",
+                "lodash.sortby": "^4.7.0"
+            },
+            "peerDependencies": {
                 "@cucumber/messages": "*"
             }
         },
         "node_modules/@cucumber/query": {
             "version": "14.7.0",
-            "resolved": "https://registry.npmjs.org/@cucumber/query/-/query-14.7.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@cucumber/query/-/query-14.7.0.tgz",
             "integrity": "sha512-fiqZ4gMEgYjmbuWproF/YeCdD5y+gD2BqgBIGbpihOsx6UlNsyzoDSfO+Tny0q65DxfK+pHo2UkPyEl7dO7wmQ==",
             "license": "MIT",
             "dependencies": {
@@ -657,14 +668,14 @@
             }
         },
         "node_modules/@cucumber/tag-expressions": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@cucumber/tag-expressions/-/tag-expressions-8.1.0.tgz",
-            "integrity": "sha512-UFeOVUyc711/E7VHjThxMwg3jbGod9TlbM1gxNixX/AGDKg82Eha4cE0tKki3GGUs7uB2NyI+hQAuhB8rL2h5A==",
+            "version": "9.1.0",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@cucumber/tag-expressions/-/tag-expressions-9.1.0.tgz",
+            "integrity": "sha512-bvHjcRFZ+J1TqIa9eFNO1wGHqwx4V9ZKV3hYgkuK/VahHx73uiP4rKV3JVrvWSMrwrFvJG6C8aEwnCWSvbyFdQ==",
             "license": "MIT"
         },
         "node_modules/@cypress/request": {
             "version": "3.0.10",
-            "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.10.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@cypress/request/-/request-3.0.10.tgz",
             "integrity": "sha512-hauBrOdvu08vOsagkZ/Aju5XuiZx6ldsLfByg1htFeldhex+PeMrYauANzFsMJeAA0+dyPLbDoX2OYuvVoLDkQ==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -693,7 +704,7 @@
         },
         "node_modules/@cypress/request/node_modules/uuid": {
             "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/uuid/-/uuid-8.3.2.tgz",
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
             "license": "MIT",
             "bin": {
@@ -702,7 +713,7 @@
         },
         "node_modules/@cypress/xvfb": {
             "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@cypress/xvfb/-/xvfb-1.2.4.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@cypress/xvfb/-/xvfb-1.2.4.tgz",
             "integrity": "sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==",
             "license": "MIT",
             "dependencies": {
@@ -712,7 +723,7 @@
         },
         "node_modules/@cypress/xvfb/node_modules/debug": {
             "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/debug/-/debug-3.2.7.tgz",
             "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
             "license": "MIT",
             "dependencies": {
@@ -721,7 +732,7 @@
         },
         "node_modules/@dependents/detective-less": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@dependents/detective-less/-/detective-less-5.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@dependents/detective-less/-/detective-less-5.0.1.tgz",
             "integrity": "sha512-Y6+WUMsTFWE5jb20IFP4YGa5IrGY/+a/FbOSjDF/wz9gepU2hwCYSXRHP/vPwBvwcY3SVMASt4yXxbXNXigmZQ==",
             "license": "MIT",
             "dependencies": {
@@ -734,7 +745,7 @@
         },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/aix-ppc64/-/aix-ppc64-0.24.0.tgz",
             "integrity": "sha512-WtKdFM7ls47zkKHFVzMz8opM7LkcsIp9amDUBIAWirg70RM71WRSjdILPsY5Uv1D42ZpUfaPILDlfactHgsRkw==",
             "cpu": [
                 "ppc64"
@@ -750,7 +761,7 @@
         },
         "node_modules/@esbuild/android-arm": {
             "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/android-arm/-/android-arm-0.24.0.tgz",
             "integrity": "sha512-arAtTPo76fJ/ICkXWetLCc9EwEHKaeya4vMrReVlEIUCAUncH7M4bhMQ+M9Vf+FFOZJdTNMXNBrWwW+OXWpSew==",
             "cpu": [
                 "arm"
@@ -766,7 +777,7 @@
         },
         "node_modules/@esbuild/android-arm64": {
             "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/android-arm64/-/android-arm64-0.24.0.tgz",
             "integrity": "sha512-Vsm497xFM7tTIPYK9bNTYJyF/lsP590Qc1WxJdlB6ljCbdZKU9SY8i7+Iin4kyhV/KV5J2rOKsBQbB77Ab7L/w==",
             "cpu": [
                 "arm64"
@@ -782,7 +793,7 @@
         },
         "node_modules/@esbuild/android-x64": {
             "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/android-x64/-/android-x64-0.24.0.tgz",
             "integrity": "sha512-t8GrvnFkiIY7pa7mMgJd7p8p8qqYIz1NYiAoKc75Zyv73L3DZW++oYMSHPRarcotTKuSs6m3hTOa5CKHaS02TQ==",
             "cpu": [
                 "x64"
@@ -798,7 +809,7 @@
         },
         "node_modules/@esbuild/darwin-arm64": {
             "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/darwin-arm64/-/darwin-arm64-0.24.0.tgz",
             "integrity": "sha512-CKyDpRbK1hXwv79soeTJNHb5EiG6ct3efd/FTPdzOWdbZZfGhpbcqIpiD0+vwmpu0wTIL97ZRPZu8vUt46nBSw==",
             "cpu": [
                 "arm64"
@@ -814,7 +825,7 @@
         },
         "node_modules/@esbuild/darwin-x64": {
             "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/darwin-x64/-/darwin-x64-0.24.0.tgz",
             "integrity": "sha512-rgtz6flkVkh58od4PwTRqxbKH9cOjaXCMZgWD905JOzjFKW+7EiUObfd/Kav+A6Gyud6WZk9w+xu6QLytdi2OA==",
             "cpu": [
                 "x64"
@@ -830,7 +841,7 @@
         },
         "node_modules/@esbuild/freebsd-arm64": {
             "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.0.tgz",
             "integrity": "sha512-6Mtdq5nHggwfDNLAHkPlyLBpE5L6hwsuXZX8XNmHno9JuL2+bg2BX5tRkwjyfn6sKbxZTq68suOjgWqCicvPXA==",
             "cpu": [
                 "arm64"
@@ -846,7 +857,7 @@
         },
         "node_modules/@esbuild/freebsd-x64": {
             "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/freebsd-x64/-/freebsd-x64-0.24.0.tgz",
             "integrity": "sha512-D3H+xh3/zphoX8ck4S2RxKR6gHlHDXXzOf6f/9dbFt/NRBDIE33+cVa49Kil4WUjxMGW0ZIYBYtaGCa2+OsQwQ==",
             "cpu": [
                 "x64"
@@ -862,7 +873,7 @@
         },
         "node_modules/@esbuild/linux-arm": {
             "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/linux-arm/-/linux-arm-0.24.0.tgz",
             "integrity": "sha512-gJKIi2IjRo5G6Glxb8d3DzYXlxdEj2NlkixPsqePSZMhLudqPhtZ4BUrpIuTjJYXxvF9njql+vRjB2oaC9XpBw==",
             "cpu": [
                 "arm"
@@ -878,7 +889,7 @@
         },
         "node_modules/@esbuild/linux-arm64": {
             "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/linux-arm64/-/linux-arm64-0.24.0.tgz",
             "integrity": "sha512-TDijPXTOeE3eaMkRYpcy3LarIg13dS9wWHRdwYRnzlwlA370rNdZqbcp0WTyyV/k2zSxfko52+C7jU5F9Tfj1g==",
             "cpu": [
                 "arm64"
@@ -894,7 +905,7 @@
         },
         "node_modules/@esbuild/linux-ia32": {
             "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/linux-ia32/-/linux-ia32-0.24.0.tgz",
             "integrity": "sha512-K40ip1LAcA0byL05TbCQ4yJ4swvnbzHscRmUilrmP9Am7//0UjPreh4lpYzvThT2Quw66MhjG//20mrufm40mA==",
             "cpu": [
                 "ia32"
@@ -910,7 +921,7 @@
         },
         "node_modules/@esbuild/linux-loong64": {
             "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/linux-loong64/-/linux-loong64-0.24.0.tgz",
             "integrity": "sha512-0mswrYP/9ai+CU0BzBfPMZ8RVm3RGAN/lmOMgW4aFUSOQBjA31UP8Mr6DDhWSuMwj7jaWOT0p0WoZ6jeHhrD7g==",
             "cpu": [
                 "loong64"
@@ -926,7 +937,7 @@
         },
         "node_modules/@esbuild/linux-mips64el": {
             "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/linux-mips64el/-/linux-mips64el-0.24.0.tgz",
             "integrity": "sha512-hIKvXm0/3w/5+RDtCJeXqMZGkI2s4oMUGj3/jM0QzhgIASWrGO5/RlzAzm5nNh/awHE0A19h/CvHQe6FaBNrRA==",
             "cpu": [
                 "mips64el"
@@ -942,7 +953,7 @@
         },
         "node_modules/@esbuild/linux-ppc64": {
             "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/linux-ppc64/-/linux-ppc64-0.24.0.tgz",
             "integrity": "sha512-HcZh5BNq0aC52UoocJxaKORfFODWXZxtBaaZNuN3PUX3MoDsChsZqopzi5UupRhPHSEHotoiptqikjN/B77mYQ==",
             "cpu": [
                 "ppc64"
@@ -958,7 +969,7 @@
         },
         "node_modules/@esbuild/linux-riscv64": {
             "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/linux-riscv64/-/linux-riscv64-0.24.0.tgz",
             "integrity": "sha512-bEh7dMn/h3QxeR2KTy1DUszQjUrIHPZKyO6aN1X4BCnhfYhuQqedHaa5MxSQA/06j3GpiIlFGSsy1c7Gf9padw==",
             "cpu": [
                 "riscv64"
@@ -974,7 +985,7 @@
         },
         "node_modules/@esbuild/linux-s390x": {
             "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/linux-s390x/-/linux-s390x-0.24.0.tgz",
             "integrity": "sha512-ZcQ6+qRkw1UcZGPyrCiHHkmBaj9SiCD8Oqd556HldP+QlpUIe2Wgn3ehQGVoPOvZvtHm8HPx+bH20c9pvbkX3g==",
             "cpu": [
                 "s390x"
@@ -990,7 +1001,7 @@
         },
         "node_modules/@esbuild/linux-x64": {
             "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/linux-x64/-/linux-x64-0.24.0.tgz",
             "integrity": "sha512-vbutsFqQ+foy3wSSbmjBXXIJ6PL3scghJoM8zCL142cGaZKAdCZHyf+Bpu/MmX9zT9Q0zFBVKb36Ma5Fzfa8xA==",
             "cpu": [
                 "x64"
@@ -1005,9 +1016,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
-            "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+            "version": "0.27.4",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+            "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
             "cpu": [
                 "arm64"
             ],
@@ -1022,7 +1033,7 @@
         },
         "node_modules/@esbuild/netbsd-x64": {
             "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/netbsd-x64/-/netbsd-x64-0.24.0.tgz",
             "integrity": "sha512-hjQ0R/ulkO8fCYFsG0FZoH+pWgTTDreqpqY7UnQntnaKv95uP5iW3+dChxnx7C3trQQU40S+OgWhUVwCjVFLvg==",
             "cpu": [
                 "x64"
@@ -1038,7 +1049,7 @@
         },
         "node_modules/@esbuild/openbsd-arm64": {
             "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.0.tgz",
             "integrity": "sha512-MD9uzzkPQbYehwcN583yx3Tu5M8EIoTD+tUgKF982WYL9Pf5rKy9ltgD0eUgs8pvKnmizxjXZyLt0z6DC3rRXg==",
             "cpu": [
                 "arm64"
@@ -1054,7 +1065,7 @@
         },
         "node_modules/@esbuild/openbsd-x64": {
             "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/openbsd-x64/-/openbsd-x64-0.24.0.tgz",
             "integrity": "sha512-4ir0aY1NGUhIC1hdoCzr1+5b43mw99uNwVzhIq1OY3QcEwPDO3B7WNXBzaKY5Nsf1+N11i1eOfFcq+D/gOS15Q==",
             "cpu": [
                 "x64"
@@ -1069,9 +1080,9 @@
             }
         },
         "node_modules/@esbuild/openharmony-arm64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
-            "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+            "version": "0.27.4",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+            "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
             "cpu": [
                 "arm64"
             ],
@@ -1086,7 +1097,7 @@
         },
         "node_modules/@esbuild/sunos-x64": {
             "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/sunos-x64/-/sunos-x64-0.24.0.tgz",
             "integrity": "sha512-jVzdzsbM5xrotH+W5f1s+JtUy1UWgjU0Cf4wMvffTB8m6wP5/kx0KiaLHlbJO+dMgtxKV8RQ/JvtlFcdZ1zCPA==",
             "cpu": [
                 "x64"
@@ -1102,7 +1113,7 @@
         },
         "node_modules/@esbuild/win32-arm64": {
             "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/win32-arm64/-/win32-arm64-0.24.0.tgz",
             "integrity": "sha512-iKc8GAslzRpBytO2/aN3d2yb2z8XTVfNV0PjGlCxKo5SgWmNXx82I/Q3aG1tFfS+A2igVCY97TJ8tnYwpUWLCA==",
             "cpu": [
                 "arm64"
@@ -1118,7 +1129,7 @@
         },
         "node_modules/@esbuild/win32-ia32": {
             "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/win32-ia32/-/win32-ia32-0.24.0.tgz",
             "integrity": "sha512-vQW36KZolfIudCcTnaTpmLQ24Ha1RjygBo39/aLkM2kmjkWmZGEJ5Gn9l5/7tzXA42QGIoWbICfg6KLLkIw6yw==",
             "cpu": [
                 "ia32"
@@ -1134,7 +1145,7 @@
         },
         "node_modules/@esbuild/win32-x64": {
             "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/win32-x64/-/win32-x64-0.24.0.tgz",
             "integrity": "sha512-7IAFPrjSQIJrGsK6flwg7NFmwBoSTyF3rl7If0hNUFQU4ilTsEPL6GuMuU9BfIWVVGuRnuIidkSMC+c0Otu8IA==",
             "cpu": [
                 "x64"
@@ -1148,30 +1159,9 @@
                 "node": ">=18"
             }
         },
-        "node_modules/@isaacs/balanced-match": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-            "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-            "license": "MIT",
-            "engines": {
-                "node": "20 || >=22"
-            }
-        },
-        "node_modules/@isaacs/brace-expansion": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-            "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-            "license": "MIT",
-            "dependencies": {
-                "@isaacs/balanced-match": "^4.0.1"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            }
-        },
         "node_modules/@isaacs/cliui": {
             "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@isaacs/cliui/-/cliui-8.0.2.tgz",
             "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
             "license": "ISC",
             "dependencies": {
@@ -1188,7 +1178,7 @@
         },
         "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
             "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/ansi-regex/-/ansi-regex-6.2.2.tgz",
             "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
             "license": "MIT",
             "engines": {
@@ -1200,7 +1190,7 @@
         },
         "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
             "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/ansi-styles/-/ansi-styles-6.2.3.tgz",
             "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
             "license": "MIT",
             "engines": {
@@ -1212,13 +1202,13 @@
         },
         "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
             "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/emoji-regex/-/emoji-regex-9.2.2.tgz",
             "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
             "license": "MIT"
         },
         "node_modules/@isaacs/cliui/node_modules/string-width": {
             "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/string-width/-/string-width-5.1.2.tgz",
             "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
             "license": "MIT",
             "dependencies": {
@@ -1234,12 +1224,12 @@
             }
         },
         "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-            "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+            "version": "7.2.0",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
             "license": "MIT",
             "dependencies": {
-                "ansi-regex": "^6.0.1"
+                "ansi-regex": "^6.2.2"
             },
             "engines": {
                 "node": ">=12"
@@ -1250,7 +1240,7 @@
         },
         "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
             "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
             "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
             "license": "MIT",
             "dependencies": {
@@ -1267,9 +1257,10 @@
         },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.13",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
             "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0",
                 "@jridgewell/trace-mapping": "^0.3.24"
@@ -1277,9 +1268,10 @@
         },
         "node_modules/@jridgewell/remapping": {
             "version": "2.3.5",
-            "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@jridgewell/remapping/-/remapping-2.3.5.tgz",
             "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.24"
@@ -1287,7 +1279,7 @@
         },
         "node_modules/@jridgewell/resolve-uri": {
             "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
             "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
             "license": "MIT",
             "engines": {
@@ -1296,13 +1288,13 @@
         },
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.5.5",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
             "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
             "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.31",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
             "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
             "license": "MIT",
             "dependencies": {
@@ -1312,7 +1304,7 @@
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
             "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
             "license": "MIT",
             "dependencies": {
@@ -1325,7 +1317,7 @@
         },
         "node_modules/@nodelib/fs.stat": {
             "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
             "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
             "license": "MIT",
             "engines": {
@@ -1334,7 +1326,7 @@
         },
         "node_modules/@nodelib/fs.walk": {
             "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
             "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
             "license": "MIT",
             "dependencies": {
@@ -1347,7 +1339,7 @@
         },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
             "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
             "license": "MIT",
             "optional": true,
@@ -1357,7 +1349,7 @@
         },
         "node_modules/@shelex/allure-js-commons-browser": {
             "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@shelex/allure-js-commons-browser/-/allure-js-commons-browser-1.5.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@shelex/allure-js-commons-browser/-/allure-js-commons-browser-1.5.0.tgz",
             "integrity": "sha512-IBZcmHTXpyfPmZgpasc4PmxAOuk+GTqxUUntmPKVU0zeauGysluFt+hJ5pPV22TLxEeKgeyl63p6ic6P3usDtg==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -1366,7 +1358,7 @@
         },
         "node_modules/@shelex/allure-js-commons-browser/node_modules/uuid": {
             "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/uuid/-/uuid-9.0.1.tgz",
             "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
             "funding": [
                 "https://github.com/sponsors/broofa",
@@ -1379,7 +1371,7 @@
         },
         "node_modules/@shelex/cypress-allure-plugin": {
             "version": "2.41.2",
-            "resolved": "https://registry.npmjs.org/@shelex/cypress-allure-plugin/-/cypress-allure-plugin-2.41.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@shelex/cypress-allure-plugin/-/cypress-allure-plugin-2.41.2.tgz",
             "integrity": "sha512-ZkXOeUW5sKKMW3rGRN9cU/YK6W7rKQyYYXKnRSoe+F0oRXh2rNVFvkdjD+N1B8sbGpWyUfxDjtLbVszLitLffg==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -1393,7 +1385,7 @@
         },
         "node_modules/@shelex/cypress-allure-plugin/node_modules/debug": {
             "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/debug/-/debug-4.4.0.tgz",
             "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
             "license": "MIT",
             "dependencies": {
@@ -1410,7 +1402,7 @@
         },
         "node_modules/@shelex/cypress-allure-plugin/node_modules/uuid": {
             "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/uuid/-/uuid-11.1.0.tgz",
             "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
             "funding": [
                 "https://github.com/sponsors/broofa",
@@ -1423,7 +1415,7 @@
         },
         "node_modules/@teppeis/multimaps": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@teppeis/multimaps/-/multimaps-3.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@teppeis/multimaps/-/multimaps-3.0.0.tgz",
             "integrity": "sha512-ID7fosbc50TbT0MK0EG12O+gAP3W3Aa/Pz4DaTtQtEvlc9Odaqi0de+xuZ7Li2GtK4HzEX7IuRWS/JmZLksR3Q==",
             "license": "MIT",
             "engines": {
@@ -1431,48 +1423,42 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.1.0.tgz",
-            "integrity": "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==",
+            "version": "25.5.0",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@types/node/-/node-25.5.0.tgz",
+            "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "undici-types": "~7.16.0"
+                "undici-types": "~7.18.0"
             }
         },
         "node_modules/@types/normalize-package-data": {
             "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
             "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
             "license": "MIT"
         },
         "node_modules/@types/sinonjs__fake-timers": {
             "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz",
             "integrity": "sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==",
             "license": "MIT"
         },
         "node_modules/@types/sizzle": {
             "version": "2.3.10",
-            "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.10.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@types/sizzle/-/sizzle-2.3.10.tgz",
             "integrity": "sha512-TC0dmN0K8YcWEAEfiPi5gJP14eJe30TTGjkvek3iM/1NdHHsdCA/Td6GvNndMOo/iSnIsZ4HuuhrYPDAmbxzww==",
             "license": "MIT"
         },
         "node_modules/@types/tmp": {
             "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@types/tmp/-/tmp-0.2.6.tgz",
             "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
-            "license": "MIT"
-        },
-        "node_modules/@types/uuid": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-            "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
             "license": "MIT"
         },
         "node_modules/@types/yauzl": {
             "version": "2.10.3",
-            "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@types/yauzl/-/yauzl-2.10.3.tgz",
             "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
             "license": "MIT",
             "optional": true,
@@ -1481,13 +1467,13 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.54.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.54.0.tgz",
-            "integrity": "sha512-YPf+rvJ1s7MyiWM4uTRhE4DvBXrEV+d8oC3P9Y2eT7S+HBS0clybdMIPnhiATi9vZOYDc7OQ1L/i6ga6NFYK/g==",
+            "version": "8.57.2",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@typescript-eslint/project-service/-/project-service-8.57.2.tgz",
+            "integrity": "sha512-FuH0wipFywXRTHf+bTTjNyuNQQsQC3qh/dYzaM4I4W0jrCqjCVuUh99+xd9KamUfmCGPvbO8NDngo/vsnNVqgw==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.54.0",
-                "@typescript-eslint/types": "^8.54.0",
+                "@typescript-eslint/tsconfig-utils": "^8.57.2",
+                "@typescript-eslint/types": "^8.57.2",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -1502,9 +1488,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.54.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.54.0.tgz",
-            "integrity": "sha512-dRgOyT2hPk/JwxNMZDsIXDgyl9axdJI3ogZ2XWhBPsnZUv+hPesa5iuhdYt2gzwA9t8RE5ytOJ6xB0moV0Ujvw==",
+            "version": "8.57.2",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.2.tgz",
+            "integrity": "sha512-3Lm5DSM+DCowsUOJC+YqHHnKEfFh5CoGkj5Z31NQSNF4l5wdOwqGn99wmwN/LImhfY3KJnmordBq/4+VDe2eKw==",
             "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1518,9 +1504,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.54.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.54.0.tgz",
-            "integrity": "sha512-PDUI9R1BVjqu7AUDsRBbKMtwmjWcn4J3le+5LpcFgWULN3LvHC5rkc9gCVxbrsrGmO1jfPybN5s6h4Jy+OnkAA==",
+            "version": "8.57.2",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@typescript-eslint/types/-/types-8.57.2.tgz",
+            "integrity": "sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==",
             "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1531,17 +1517,17 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.54.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.54.0.tgz",
-            "integrity": "sha512-BUwcskRaPvTk6fzVWgDPdUndLjB87KYDrN5EYGetnktoeAvPtO4ONHlAZDnj5VFnUANg0Sjm7j4usBlnoVMHwA==",
+            "version": "8.57.2",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.2.tgz",
+            "integrity": "sha512-2MKM+I6g8tJxfSmFKOnHv2t8Sk3T6rF20A1Puk0svLK+uVapDZB/4pfAeB7nE83uAZrU6OxW+HmOd5wHVdXwXA==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.54.0",
-                "@typescript-eslint/tsconfig-utils": "8.54.0",
-                "@typescript-eslint/types": "8.54.0",
-                "@typescript-eslint/visitor-keys": "8.54.0",
+                "@typescript-eslint/project-service": "8.57.2",
+                "@typescript-eslint/tsconfig-utils": "8.57.2",
+                "@typescript-eslint/types": "8.57.2",
+                "@typescript-eslint/visitor-keys": "8.57.2",
                 "debug": "^4.4.3",
-                "minimatch": "^9.0.5",
+                "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
                 "tinyglobby": "^0.2.15",
                 "ts-api-utils": "^2.4.0"
@@ -1557,29 +1543,14 @@
                 "typescript": ">=4.8.4 <6.0.0"
             }
         },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.54.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.54.0.tgz",
-            "integrity": "sha512-VFlhGSl4opC0bprJiItPQ1RfUhGDIBokcPwaFH4yiBCaNPeld/9VeXbiPO1cLyorQi1G1vL+ecBk1x8o1axORA==",
+            "version": "8.57.2",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.2.tgz",
+            "integrity": "sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.54.0",
-                "eslint-visitor-keys": "^4.2.1"
+                "@typescript-eslint/types": "8.57.2",
+                "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1590,65 +1561,65 @@
             }
         },
         "node_modules/@vue/compiler-core": {
-            "version": "3.5.27",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.27.tgz",
-            "integrity": "sha512-gnSBQjZA+//qDZen+6a2EdHqJ68Z7uybrMf3SPjEGgG4dicklwDVmMC1AeIHxtLVPT7sn6sH1KOO+tS6gwOUeQ==",
+            "version": "3.5.31",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@vue/compiler-core/-/compiler-core-3.5.31.tgz",
+            "integrity": "sha512-k/ueL14aNIEy5Onf0OVzR8kiqF/WThgLdFhxwa4e/KF/0qe38IwIdofoSWBTvvxQOesaz6riAFAUaYjoF9fLLQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.28.5",
-                "@vue/shared": "3.5.27",
-                "entities": "^7.0.0",
+                "@babel/parser": "^7.29.2",
+                "@vue/shared": "3.5.31",
+                "entities": "^7.0.1",
                 "estree-walker": "^2.0.2",
                 "source-map-js": "^1.2.1"
             }
         },
         "node_modules/@vue/compiler-dom": {
-            "version": "3.5.27",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.27.tgz",
-            "integrity": "sha512-oAFea8dZgCtVVVTEC7fv3T5CbZW9BxpFzGGxC79xakTr6ooeEqmRuvQydIiDAkglZEAd09LgVf1RoDnL54fu5w==",
+            "version": "3.5.31",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@vue/compiler-dom/-/compiler-dom-3.5.31.tgz",
+            "integrity": "sha512-BMY/ozS/xxjYqRFL+tKdRpATJYDTTgWSo0+AJvJNg4ig+Hgb0dOsHPXvloHQ5hmlivUqw1Yt2pPIqp4e0v1GUw==",
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-core": "3.5.27",
-                "@vue/shared": "3.5.27"
+                "@vue/compiler-core": "3.5.31",
+                "@vue/shared": "3.5.31"
             }
         },
         "node_modules/@vue/compiler-sfc": {
-            "version": "3.5.27",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.27.tgz",
-            "integrity": "sha512-sHZu9QyDPeDmN/MRoshhggVOWE5WlGFStKFwu8G52swATgSny27hJRWteKDSUUzUH+wp+bmeNbhJnEAel/auUQ==",
+            "version": "3.5.31",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@vue/compiler-sfc/-/compiler-sfc-3.5.31.tgz",
+            "integrity": "sha512-M8wpPgR9UJ8MiRGjppvx9uWJfLV7A/T+/rL8s/y3QG3u0c2/YZgff3d6SuimKRIhcYnWg5fTfDMlz2E6seUW8Q==",
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.28.5",
-                "@vue/compiler-core": "3.5.27",
-                "@vue/compiler-dom": "3.5.27",
-                "@vue/compiler-ssr": "3.5.27",
-                "@vue/shared": "3.5.27",
+                "@babel/parser": "^7.29.2",
+                "@vue/compiler-core": "3.5.31",
+                "@vue/compiler-dom": "3.5.31",
+                "@vue/compiler-ssr": "3.5.31",
+                "@vue/shared": "3.5.31",
                 "estree-walker": "^2.0.2",
                 "magic-string": "^0.30.21",
-                "postcss": "^8.5.6",
+                "postcss": "^8.5.8",
                 "source-map-js": "^1.2.1"
             }
         },
         "node_modules/@vue/compiler-ssr": {
-            "version": "3.5.27",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.27.tgz",
-            "integrity": "sha512-Sj7h+JHt512fV1cTxKlYhg7qxBvack+BGncSpH+8vnN+KN95iPIcqB5rsbblX40XorP+ilO7VIKlkuu3Xq2vjw==",
+            "version": "3.5.31",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@vue/compiler-ssr/-/compiler-ssr-3.5.31.tgz",
+            "integrity": "sha512-h0xIMxrt/LHOvJKMri+vdYT92BrK3HFLtDqq9Pr/lVVfE4IyKZKvWf0vJFW10Yr6nX02OR4MkJwI0c1HDa1hog==",
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-dom": "3.5.27",
-                "@vue/shared": "3.5.27"
+                "@vue/compiler-dom": "3.5.31",
+                "@vue/shared": "3.5.31"
             }
         },
         "node_modules/@vue/shared": {
-            "version": "3.5.27",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.27.tgz",
-            "integrity": "sha512-dXr/3CgqXsJkZ0n9F3I4elY8wM9jMJpP3pvRG52r6m0tu/MsAFIe6JpXVGeNMd/D9F4hQynWT8Rfuj0bdm9kFQ==",
+            "version": "3.5.31",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@vue/shared/-/shared-3.5.31.tgz",
+            "integrity": "sha512-nBxuiuS9Lj5bPkPbWogPUnjxxWpkRniX7e5UBQDWl6Fsf4roq9wwV+cR7ezQ4zXswNvPIlsdj1slcLB7XCsRAw==",
             "license": "MIT"
         },
         "node_modules/acorn": {
-            "version": "8.15.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-            "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+            "version": "8.16.0",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/acorn/-/acorn-8.16.0.tgz",
+            "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
@@ -1658,9 +1629,9 @@
             }
         },
         "node_modules/acorn-walk": {
-            "version": "8.3.4",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-            "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+            "version": "8.3.5",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/acorn-walk/-/acorn-walk-8.3.5.tgz",
+            "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
             "license": "MIT",
             "dependencies": {
                 "acorn": "^8.11.0"
@@ -1671,7 +1642,7 @@
         },
         "node_modules/aggregate-error": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/aggregate-error/-/aggregate-error-3.1.0.tgz",
             "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
             "license": "MIT",
             "dependencies": {
@@ -1684,7 +1655,7 @@
         },
         "node_modules/ansi-colors": {
             "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/ansi-colors/-/ansi-colors-4.1.3.tgz",
             "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
             "license": "MIT",
             "engines": {
@@ -1693,7 +1664,7 @@
         },
         "node_modules/ansi-escapes": {
             "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
             "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
             "license": "MIT",
             "dependencies": {
@@ -1708,7 +1679,7 @@
         },
         "node_modules/ansi-escapes/node_modules/type-fest": {
             "version": "0.21.3",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/type-fest/-/type-fest-0.21.3.tgz",
             "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
             "license": "(MIT OR CC0-1.0)",
             "engines": {
@@ -1720,7 +1691,7 @@
         },
         "node_modules/ansi-regex": {
             "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/ansi-regex/-/ansi-regex-4.1.1.tgz",
             "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
             "license": "MIT",
             "engines": {
@@ -1728,12 +1699,15 @@
             }
         },
         "node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "version": "4.3.0",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
             "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
             "engines": {
-                "node": ">=10"
+                "node": ">=8"
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -1741,19 +1715,19 @@
         },
         "node_modules/any-promise": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/any-promise/-/any-promise-1.3.0.tgz",
             "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
             "license": "MIT"
         },
         "node_modules/app-module-path": {
             "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/app-module-path/-/app-module-path-2.2.0.tgz",
             "integrity": "sha512-gkco+qxENJV+8vFcDiiFhuoSvRXb2a/QPqpSoWhVz829VNJfOTnELbBmPmNKFxf3xdNnw4DWCkzkDaavcX/1YQ==",
             "license": "BSD-2-Clause"
         },
         "node_modules/arch": {
             "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/arch/-/arch-2.2.0.tgz",
             "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
             "funding": [
                 {
@@ -1773,19 +1747,19 @@
         },
         "node_modules/arg": {
             "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/arg/-/arg-5.0.2.tgz",
             "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
             "license": "MIT"
         },
         "node_modules/argparse": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "license": "Python-2.0"
         },
         "node_modules/array-buffer-byte-length": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
             "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
             "license": "MIT",
             "dependencies": {
@@ -1801,7 +1775,7 @@
         },
         "node_modules/asn1": {
             "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/asn1/-/asn1-0.2.6.tgz",
             "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
             "license": "MIT",
             "dependencies": {
@@ -1810,7 +1784,7 @@
         },
         "node_modules/assert-plus": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/assert-plus/-/assert-plus-1.0.0.tgz",
             "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
             "license": "MIT",
             "engines": {
@@ -1819,7 +1793,7 @@
         },
         "node_modules/assertion-error-formatter": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/assertion-error-formatter/-/assertion-error-formatter-3.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/assertion-error-formatter/-/assertion-error-formatter-3.0.0.tgz",
             "integrity": "sha512-6YyAVLrEze0kQ7CmJfUgrLHb+Y7XghmL2Ie7ijVa2Y9ynP3LV+VDiwFk62Dn0qtqbmY0BT0ss6p1xxpiF2PYbQ==",
             "license": "MIT",
             "dependencies": {
@@ -1830,7 +1804,7 @@
         },
         "node_modules/ast-module-types": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-6.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/ast-module-types/-/ast-module-types-6.0.1.tgz",
             "integrity": "sha512-WHw67kLXYbZuHTmcdbIrVArCq5wxo6NEuj3hiYAWr8mwJeC+C2mMCIBIWCiDoCye/OF/xelc+teJ1ERoWmnEIA==",
             "license": "MIT",
             "engines": {
@@ -1839,7 +1813,7 @@
         },
         "node_modules/astral-regex": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/astral-regex/-/astral-regex-2.0.0.tgz",
             "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
             "license": "MIT",
             "engines": {
@@ -1848,13 +1822,13 @@
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
             "license": "MIT"
         },
         "node_modules/at-least-node": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/at-least-node/-/at-least-node-1.0.0.tgz",
             "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
             "license": "ISC",
             "engines": {
@@ -1863,7 +1837,7 @@
         },
         "node_modules/available-typed-arrays": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
             "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
             "license": "MIT",
             "dependencies": {
@@ -1878,7 +1852,7 @@
         },
         "node_modules/aws-sign2": {
             "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/aws-sign2/-/aws-sign2-0.7.0.tgz",
             "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
             "license": "Apache-2.0",
             "engines": {
@@ -1887,19 +1861,22 @@
         },
         "node_modules/aws4": {
             "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/aws4/-/aws4-1.13.2.tgz",
             "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
             "license": "MIT"
         },
         "node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "license": "MIT"
+            "version": "4.0.4",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
         },
         "node_modules/base64-js": {
             "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/base64-js/-/base64-js-1.5.1.tgz",
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
             "funding": [
                 {
@@ -1918,17 +1895,21 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.9.19",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
-            "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+            "version": "2.10.10",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/baseline-browser-mapping/-/baseline-browser-mapping-2.10.10.tgz",
+            "integrity": "sha512-sUoJ3IMxx4AyRqO4MLeHlnGDkyXRoUG0/AI9fjK+vS72ekpV0yWVY7O0BVjmBcRtkNcsAO2QDZ4tdKKGoI6YaQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
-                "baseline-browser-mapping": "dist/cli.js"
+                "baseline-browser-mapping": "dist/cli.cjs"
+            },
+            "engines": {
+                "node": ">=6.0.0"
             }
         },
         "node_modules/bcrypt-pbkdf": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
             "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -1937,28 +1918,31 @@
         },
         "node_modules/blob-util": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/blob-util/-/blob-util-2.0.2.tgz",
             "integrity": "sha512-T7JQa+zsXXEa6/8ZhHcQEW1UFfVM49Ts65uBkFL6fz2QmrElqmbajIDJvuA0tEhRe5eIjpV9ZF+0RfZR9voJFQ==",
             "license": "Apache-2.0"
         },
         "node_modules/bluebird": {
             "version": "3.7.2",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/bluebird/-/bluebird-3.7.2.tgz",
             "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "5.0.5",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/brace-expansion/-/brace-expansion-5.0.5.tgz",
+            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
             "license": "MIT",
             "dependencies": {
-                "balanced-match": "^1.0.0"
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
             }
         },
         "node_modules/braces": {
             "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/braces/-/braces-3.0.3.tgz",
             "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "license": "MIT",
             "dependencies": {
@@ -1970,13 +1954,13 @@
         },
         "node_modules/browser-stdout": {
             "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/browser-stdout/-/browser-stdout-1.3.1.tgz",
             "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
             "license": "ISC"
         },
         "node_modules/browserslist": {
             "version": "4.28.1",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/browserslist/-/browserslist-4.28.1.tgz",
             "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
             "funding": [
                 {
@@ -2010,7 +1994,7 @@
         },
         "node_modules/buffer": {
             "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/buffer/-/buffer-5.7.1.tgz",
             "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
             "funding": [
                 {
@@ -2034,7 +2018,7 @@
         },
         "node_modules/buffer-crc32": {
             "version": "0.2.13",
-            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
             "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
             "license": "MIT",
             "engines": {
@@ -2043,13 +2027,13 @@
         },
         "node_modules/buffer-from": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
             "license": "MIT"
         },
         "node_modules/cachedir": {
             "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/cachedir/-/cachedir-2.4.0.tgz",
             "integrity": "sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==",
             "license": "MIT",
             "engines": {
@@ -2058,7 +2042,7 @@
         },
         "node_modules/call-bind": {
             "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/call-bind/-/call-bind-1.0.8.tgz",
             "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
             "license": "MIT",
             "dependencies": {
@@ -2076,7 +2060,7 @@
         },
         "node_modules/call-bind-apply-helpers": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
             "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
             "license": "MIT",
             "dependencies": {
@@ -2089,7 +2073,7 @@
         },
         "node_modules/call-bound": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/call-bound/-/call-bound-1.0.4.tgz",
             "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
             "license": "MIT",
             "dependencies": {
@@ -2105,7 +2089,7 @@
         },
         "node_modules/callsites": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/callsites/-/callsites-3.1.0.tgz",
             "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
             "license": "MIT",
             "engines": {
@@ -2114,7 +2098,7 @@
         },
         "node_modules/camelcase": {
             "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/camelcase/-/camelcase-6.3.0.tgz",
             "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
             "license": "MIT",
             "engines": {
@@ -2125,9 +2109,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001766",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001766.tgz",
-            "integrity": "sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA==",
+            "version": "1.0.30001781",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
+            "integrity": "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -2142,11 +2126,12 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "CC-BY-4.0"
+            "license": "CC-BY-4.0",
+            "peer": true
         },
         "node_modules/capital-case": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/capital-case/-/capital-case-1.0.4.tgz",
             "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
             "license": "MIT",
             "dependencies": {
@@ -2157,13 +2142,13 @@
         },
         "node_modules/caseless": {
             "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/caseless/-/caseless-0.12.0.tgz",
             "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
             "license": "Apache-2.0"
         },
         "node_modules/chalk": {
             "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
             "license": "MIT",
             "dependencies": {
@@ -2177,24 +2162,9 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
-        "node_modules/chalk/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "license": "MIT",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
         "node_modules/chalk/node_modules/supports-color": {
             "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
             "license": "MIT",
             "dependencies": {
@@ -2206,7 +2176,7 @@
         },
         "node_modules/chokidar": {
             "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/chokidar/-/chokidar-4.0.3.tgz",
             "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
             "license": "MIT",
             "dependencies": {
@@ -2220,9 +2190,9 @@
             }
         },
         "node_modules/ci-info": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
-            "integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
+            "version": "4.4.0",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/ci-info/-/ci-info-4.4.0.tgz",
+            "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
             "funding": [
                 {
                     "type": "github",
@@ -2236,13 +2206,13 @@
         },
         "node_modules/class-transformer": {
             "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/class-transformer/-/class-transformer-0.5.1.tgz",
             "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
             "license": "MIT"
         },
         "node_modules/clean-stack": {
             "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/clean-stack/-/clean-stack-2.2.0.tgz",
             "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
             "license": "MIT",
             "engines": {
@@ -2251,7 +2221,7 @@
         },
         "node_modules/cli-cursor": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/cli-cursor/-/cli-cursor-3.1.0.tgz",
             "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
             "license": "MIT",
             "dependencies": {
@@ -2263,7 +2233,7 @@
         },
         "node_modules/cli-table": {
             "version": "0.3.11",
-            "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.11.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/cli-table/-/cli-table-0.3.11.tgz",
             "integrity": "sha512-IqLQi4lO0nIB4tcdTpN4LCB9FI3uqrJZK7RC515EnhZ6qBaglkIgICb1wjeAqpdoOabm1+SuQtkXIPdYC93jhQ==",
             "dependencies": {
                 "colors": "1.0.3"
@@ -2274,7 +2244,7 @@
         },
         "node_modules/cli-table3": {
             "version": "0.6.5",
-            "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/cli-table3/-/cli-table3-0.6.5.tgz",
             "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
             "license": "MIT",
             "dependencies": {
@@ -2289,7 +2259,7 @@
         },
         "node_modules/cli-truncate": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/cli-truncate/-/cli-truncate-2.1.0.tgz",
             "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
             "license": "MIT",
             "dependencies": {
@@ -2305,7 +2275,7 @@
         },
         "node_modules/cliui": {
             "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/cliui/-/cliui-8.0.1.tgz",
             "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
             "license": "ISC",
             "dependencies": {
@@ -2319,7 +2289,7 @@
         },
         "node_modules/clone": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/clone/-/clone-1.0.4.tgz",
             "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
             "license": "MIT",
             "optional": true,
@@ -2329,7 +2299,7 @@
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
             "license": "MIT",
             "dependencies": {
@@ -2341,19 +2311,19 @@
         },
         "node_modules/color-name": {
             "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "license": "MIT"
         },
         "node_modules/colorette": {
             "version": "2.0.20",
-            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/colorette/-/colorette-2.0.20.tgz",
             "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
             "license": "MIT"
         },
         "node_modules/colors": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/colors/-/colors-1.0.3.tgz",
             "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
             "license": "MIT",
             "engines": {
@@ -2362,7 +2332,7 @@
         },
         "node_modules/combined-stream": {
             "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
             "license": "MIT",
             "dependencies": {
@@ -2373,9 +2343,9 @@
             }
         },
         "node_modules/commander": {
-            "version": "14.0.2",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
-            "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
+            "version": "14.0.3",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/commander/-/commander-14.0.3.tgz",
+            "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
             "license": "MIT",
             "engines": {
                 "node": ">=20"
@@ -2383,7 +2353,7 @@
         },
         "node_modules/common-ancestor-path": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-2.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/common-ancestor-path/-/common-ancestor-path-2.0.0.tgz",
             "integrity": "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==",
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -2392,22 +2362,16 @@
         },
         "node_modules/common-tags": {
             "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/common-tags/-/common-tags-1.8.2.tgz",
             "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
             "license": "MIT",
             "engines": {
                 "node": ">=4.0.0"
             }
         },
-        "node_modules/concat-map": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-            "license": "MIT"
-        },
         "node_modules/console.table": {
             "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/console.table/-/console.table-0.10.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/console.table/-/console.table-0.10.0.tgz",
             "integrity": "sha512-dPyZofqggxuvSf7WXvNjuRfnsOk1YazkVP8FdxH4tcH2c37wc79/Yl6Bhr7Lsu00KMgy2ql/qCMuNu8xctZM8g==",
             "license": "MIT",
             "dependencies": {
@@ -2419,20 +2383,21 @@
         },
         "node_modules/convert-source-map": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/convert-source-map/-/convert-source-map-2.0.0.tgz",
             "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/core-util-is": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
             "license": "MIT"
         },
         "node_modules/cosmiconfig": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-            "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+            "version": "9.0.1",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+            "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
             "license": "MIT",
             "dependencies": {
                 "env-paths": "^2.2.1",
@@ -2457,7 +2422,7 @@
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/cross-spawn/-/cross-spawn-7.0.6.tgz",
             "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "license": "MIT",
             "dependencies": {
@@ -2471,17 +2436,16 @@
         },
         "node_modules/crypto-js": {
             "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/crypto-js/-/crypto-js-4.2.0.tgz",
             "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
             "license": "MIT"
         },
         "node_modules/cypress": {
-            "version": "15.9.0",
-            "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.9.0.tgz",
-            "integrity": "sha512-Ks6Bdilz3TtkLZtTQyqYaqtL/WT3X3APKaSLhTV96TmTyudzSjc6EJsJCHmBb7DxO+3R12q3Jkbjgm/iPgmwfg==",
+            "version": "15.12.0",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/cypress/-/cypress-15.12.0.tgz",
+            "integrity": "sha512-B2BRcudLfA4NZZP5QpA45J70bu1heCH59V1yKRLHAtiC49r7RV03X5ifUh7Nfbk8QNg93RAsc6oAmodm/+j0pA==",
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@cypress/request": "^3.0.10",
                 "@cypress/xvfb": "^1.2.4",
@@ -2511,7 +2475,7 @@
                 "hasha": "5.2.2",
                 "is-installed-globally": "~0.4.0",
                 "listr2": "^3.8.3",
-                "lodash": "^4.17.21",
+                "lodash": "^4.17.23",
                 "log-symbols": "^4.0.0",
                 "minimist": "^1.2.8",
                 "ospath": "^1.2.2",
@@ -2520,9 +2484,10 @@
                 "proxy-from-env": "1.0.0",
                 "request-progress": "^3.0.0",
                 "supports-color": "^8.1.1",
-                "systeminformation": "^5.27.14",
+                "systeminformation": "^5.31.1",
                 "tmp": "~0.2.4",
                 "tree-kill": "1.2.2",
+                "tslib": "1.14.1",
                 "untildify": "^4.0.0",
                 "yauzl": "^2.10.0"
             },
@@ -2535,7 +2500,7 @@
         },
         "node_modules/cypress/node_modules/cli-table3": {
             "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/cli-table3/-/cli-table3-0.6.1.tgz",
             "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
             "license": "MIT",
             "dependencies": {
@@ -2550,7 +2515,7 @@
         },
         "node_modules/cypress/node_modules/colors": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/colors/-/colors-1.4.0.tgz",
             "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
             "license": "MIT",
             "optional": true,
@@ -2560,16 +2525,22 @@
         },
         "node_modules/cypress/node_modules/commander": {
             "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/commander/-/commander-6.2.1.tgz",
             "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
             "license": "MIT",
             "engines": {
                 "node": ">= 6"
             }
         },
+        "node_modules/cypress/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "license": "0BSD"
+        },
         "node_modules/dashdash": {
             "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
             "license": "MIT",
             "dependencies": {
@@ -2580,14 +2551,14 @@
             }
         },
         "node_modules/dayjs": {
-            "version": "1.11.19",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
-            "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
+            "version": "1.11.20",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/dayjs/-/dayjs-1.11.20.tgz",
+            "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
             "license": "MIT"
         },
         "node_modules/debug": {
             "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/debug/-/debug-4.4.3.tgz",
             "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "license": "MIT",
             "dependencies": {
@@ -2604,7 +2575,7 @@
         },
         "node_modules/decamelize": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/decamelize/-/decamelize-4.0.0.tgz",
             "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
             "license": "MIT",
             "engines": {
@@ -2616,7 +2587,7 @@
         },
         "node_modules/deep-equal": {
             "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/deep-equal/-/deep-equal-2.2.3.tgz",
             "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
             "license": "MIT",
             "dependencies": {
@@ -2648,7 +2619,7 @@
         },
         "node_modules/defaults": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/defaults/-/defaults-1.0.4.tgz",
             "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
             "license": "MIT",
             "optional": true,
@@ -2661,7 +2632,7 @@
         },
         "node_modules/define-data-property": {
             "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/define-data-property/-/define-data-property-1.1.4.tgz",
             "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
             "license": "MIT",
             "dependencies": {
@@ -2678,7 +2649,7 @@
         },
         "node_modules/define-properties": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/define-properties/-/define-properties-1.2.1.tgz",
             "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
             "license": "MIT",
             "dependencies": {
@@ -2695,7 +2666,7 @@
         },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
             "license": "MIT",
             "engines": {
@@ -2703,15 +2674,15 @@
             }
         },
         "node_modules/dependency-tree": {
-            "version": "11.2.0",
-            "resolved": "https://registry.npmjs.org/dependency-tree/-/dependency-tree-11.2.0.tgz",
-            "integrity": "sha512-+C1H3mXhcvMCeu5i2Jpg9dc0N29TWTuT6vJD7mHLAfVmAbo9zW8NlkvQ1tYd3PDMab0IRQM0ccoyX68EZtx9xw==",
+            "version": "11.4.0",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/dependency-tree/-/dependency-tree-11.4.0.tgz",
+            "integrity": "sha512-r4wZ1pfv8eQrnoWbIGdrJTVmlb0dkXdwBjKsotKO4gmfqrOsAMG+0+cfA5EZ3NO8umc85twXOl1eO27E5pjTzw==",
             "license": "MIT",
             "dependencies": {
                 "commander": "^12.1.0",
-                "filing-cabinet": "^5.0.3",
+                "filing-cabinet": "^5.2.0",
                 "precinct": "^12.2.0",
-                "typescript": "^5.8.3"
+                "typescript": "^5.9.3"
             },
             "bin": {
                 "dependency-tree": "bin/cli.js"
@@ -2722,7 +2693,7 @@
         },
         "node_modules/dependency-tree/node_modules/commander": {
             "version": "12.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/commander/-/commander-12.1.0.tgz",
             "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
             "license": "MIT",
             "engines": {
@@ -2731,7 +2702,7 @@
         },
         "node_modules/detective-amd": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/detective-amd/-/detective-amd-6.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/detective-amd/-/detective-amd-6.0.1.tgz",
             "integrity": "sha512-TtyZ3OhwUoEEIhTFoc1C9IyJIud3y+xYkSRjmvCt65+ycQuc3VcBrPRTMWoO/AnuCyOB8T5gky+xf7Igxtjd3g==",
             "license": "MIT",
             "dependencies": {
@@ -2748,9 +2719,9 @@
             }
         },
         "node_modules/detective-cjs": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/detective-cjs/-/detective-cjs-6.0.1.tgz",
-            "integrity": "sha512-tLTQsWvd2WMcmn/60T2inEJNhJoi7a//PQ7DwRKEj1yEeiQs4mrONgsUtEJKnZmrGWBBmE0kJ1vqOG/NAxwaJw==",
+            "version": "6.1.0",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/detective-cjs/-/detective-cjs-6.1.0.tgz",
+            "integrity": "sha512-Qt3S4IddVNDb+71lm+jmt5NznIsgcKlibTnrw9Zr91rT9vRwKp+73+ImqLTNrQj4YuOxnzrC7GwIAVwF7136XQ==",
             "license": "MIT",
             "dependencies": {
                 "ast-module-types": "^6.0.1",
@@ -2762,7 +2733,7 @@
         },
         "node_modules/detective-es6": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/detective-es6/-/detective-es6-5.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/detective-es6/-/detective-es6-5.0.1.tgz",
             "integrity": "sha512-XusTPuewnSUdoxRSx8OOI6xIA/uld/wMQwYsouvFN2LAg7HgP06NF1lHRV3x6BZxyL2Kkoih4ewcq8hcbGtwew==",
             "license": "MIT",
             "dependencies": {
@@ -2774,7 +2745,7 @@
         },
         "node_modules/detective-postcss": {
             "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/detective-postcss/-/detective-postcss-7.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/detective-postcss/-/detective-postcss-7.0.1.tgz",
             "integrity": "sha512-bEOVpHU9picRZux5XnwGsmCN4+8oZo7vSW0O0/Enq/TO5R2pIAP2279NsszpJR7ocnQt4WXU0+nnh/0JuK4KHQ==",
             "license": "MIT",
             "dependencies": {
@@ -2790,7 +2761,7 @@
         },
         "node_modules/detective-sass": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/detective-sass/-/detective-sass-6.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/detective-sass/-/detective-sass-6.0.1.tgz",
             "integrity": "sha512-jSGPO8QDy7K7pztUmGC6aiHkexBQT4GIH+mBAL9ZyBmnUIOFbkfZnO8wPRRJFP/QP83irObgsZHCoDHZ173tRw==",
             "license": "MIT",
             "dependencies": {
@@ -2803,7 +2774,7 @@
         },
         "node_modules/detective-scss": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/detective-scss/-/detective-scss-5.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/detective-scss/-/detective-scss-5.0.1.tgz",
             "integrity": "sha512-MAyPYRgS6DCiS6n6AoSBJXLGVOydsr9huwXORUlJ37K3YLyiN0vYHpzs3AdJOgHobBfispokoqrEon9rbmKacg==",
             "license": "MIT",
             "dependencies": {
@@ -2816,7 +2787,7 @@
         },
         "node_modules/detective-stylus": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/detective-stylus/-/detective-stylus-5.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/detective-stylus/-/detective-stylus-5.0.1.tgz",
             "integrity": "sha512-Dgn0bUqdGbE3oZJ+WCKf8Dmu7VWLcmRJGc6RCzBgG31DLIyai9WAoEhYRgIHpt/BCRMrnXLbGWGPQuBUrnF0TA==",
             "license": "MIT",
             "engines": {
@@ -2825,7 +2796,7 @@
         },
         "node_modules/detective-typescript": {
             "version": "14.0.0",
-            "resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-14.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/detective-typescript/-/detective-typescript-14.0.0.tgz",
             "integrity": "sha512-pgN43/80MmWVSEi5LUuiVvO/0a9ss5V7fwVfrJ4QzAQRd3cwqU1SfWGXJFcNKUqoD5cS+uIovhw5t/0rSeC5Mw==",
             "license": "MIT",
             "dependencies": {
@@ -2842,7 +2813,7 @@
         },
         "node_modules/detective-vue2": {
             "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/detective-vue2/-/detective-vue2-2.2.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/detective-vue2/-/detective-vue2-2.2.0.tgz",
             "integrity": "sha512-sVg/t6O2z1zna8a/UIV6xL5KUa2cMTQbdTIIvqNM0NIPswp52fe43Nwmbahzj3ww4D844u/vC2PYfiGLvD3zFA==",
             "license": "MIT",
             "dependencies": {
@@ -2863,7 +2834,7 @@
         },
         "node_modules/diff": {
             "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/diff/-/diff-4.0.4.tgz",
             "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
             "license": "BSD-3-Clause",
             "engines": {
@@ -2872,7 +2843,7 @@
         },
         "node_modules/dunder-proto": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/dunder-proto/-/dunder-proto-1.0.1.tgz",
             "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
             "license": "MIT",
             "dependencies": {
@@ -2886,13 +2857,13 @@
         },
         "node_modules/eastasianwidth": {
             "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
             "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
             "license": "MIT"
         },
         "node_modules/easy-table": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/easy-table/-/easy-table-1.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/easy-table/-/easy-table-1.1.0.tgz",
             "integrity": "sha512-oq33hWOSSnl2Hoh00tZWaIPi1ievrD9aFG82/IgjlycAnW9hHx5PkJiXpxPsgEE+H7BsbVQXFVFST8TEXS6/pA==",
             "license": "MIT",
             "optionalDependencies": {
@@ -2901,7 +2872,7 @@
         },
         "node_modules/ecc-jsbn": {
             "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
             "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
             "license": "MIT",
             "dependencies": {
@@ -2910,20 +2881,21 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.282",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.282.tgz",
-            "integrity": "sha512-FCPkJtpst28UmFzd903iU7PdeVTfY0KAeJy+Lk0GLZRwgwYHn/irRcaCbQQOmr5Vytc/7rcavsYLvTM8RiHYhQ==",
-            "license": "ISC"
+            "version": "1.5.325",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/electron-to-chromium/-/electron-to-chromium-1.5.325.tgz",
+            "integrity": "sha512-PwfIw7WQSt3xX7yOf5OE/unLzsK9CaN2f/FvV3WjPR1Knoc1T9vePRVV4W1EM301JzzysK51K7FNKcusCr0zYA==",
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "license": "MIT"
         },
         "node_modules/end-of-stream": {
             "version": "1.4.5",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/end-of-stream/-/end-of-stream-1.4.5.tgz",
             "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
             "license": "MIT",
             "dependencies": {
@@ -2931,13 +2903,13 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.18.4",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
-            "integrity": "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==",
+            "version": "5.20.1",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+            "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.4",
-                "tapable": "^2.2.0"
+                "tapable": "^2.3.0"
             },
             "engines": {
                 "node": ">=10.13.0"
@@ -2945,10 +2917,9 @@
         },
         "node_modules/enquirer": {
             "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/enquirer/-/enquirer-2.4.1.tgz",
             "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-colors": "^4.1.1",
                 "strip-ansi": "^6.0.1"
@@ -2959,7 +2930,7 @@
         },
         "node_modules/entities": {
             "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/entities/-/entities-7.0.1.tgz",
             "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
             "license": "BSD-2-Clause",
             "engines": {
@@ -2971,7 +2942,7 @@
         },
         "node_modules/env-paths": {
             "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/env-paths/-/env-paths-2.2.1.tgz",
             "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
             "license": "MIT",
             "engines": {
@@ -2980,7 +2951,7 @@
         },
         "node_modules/error-ex": {
             "version": "1.3.4",
-            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/error-ex/-/error-ex-1.3.4.tgz",
             "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
             "license": "MIT",
             "dependencies": {
@@ -2989,7 +2960,7 @@
         },
         "node_modules/error-stack-parser": {
             "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
             "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
             "license": "MIT",
             "dependencies": {
@@ -2998,7 +2969,7 @@
         },
         "node_modules/es-define-property": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/es-define-property/-/es-define-property-1.0.1.tgz",
             "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
             "license": "MIT",
             "engines": {
@@ -3007,7 +2978,7 @@
         },
         "node_modules/es-errors": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
             "license": "MIT",
             "engines": {
@@ -3016,7 +2987,7 @@
         },
         "node_modules/es-get-iterator": {
             "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
             "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
             "license": "MIT",
             "dependencies": {
@@ -3036,7 +3007,7 @@
         },
         "node_modules/es-object-atoms": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
             "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
             "license": "MIT",
             "dependencies": {
@@ -3048,7 +3019,7 @@
         },
         "node_modules/es-set-tostringtag": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
             "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
             "license": "MIT",
             "dependencies": {
@@ -3063,11 +3034,10 @@
         },
         "node_modules/esbuild": {
             "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/esbuild/-/esbuild-0.24.0.tgz",
             "integrity": "sha512-FuLPevChGDshgSicjisSooU0cemp/sGXR841D5LHMB7mTVOmsEHcAxaH3irL53+8YDIeVNQEySh4DaYU/iuPqQ==",
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -3103,7 +3073,7 @@
         },
         "node_modules/escalade": {
             "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/escalade/-/escalade-3.2.0.tgz",
             "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
             "license": "MIT",
             "engines": {
@@ -3112,7 +3082,7 @@
         },
         "node_modules/escape-string-regexp": {
             "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
             "license": "MIT",
             "engines": {
@@ -3121,7 +3091,7 @@
         },
         "node_modules/escodegen": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/escodegen/-/escodegen-2.1.0.tgz",
             "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -3141,12 +3111,12 @@
             }
         },
         "node_modules/eslint-visitor-keys": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+            "version": "5.0.1",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
             "license": "Apache-2.0",
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
@@ -3154,7 +3124,7 @@
         },
         "node_modules/esprima": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/esprima/-/esprima-4.0.1.tgz",
             "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
             "license": "BSD-2-Clause",
             "bin": {
@@ -3167,7 +3137,7 @@
         },
         "node_modules/estraverse": {
             "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
             "license": "BSD-2-Clause",
             "engines": {
@@ -3176,13 +3146,13 @@
         },
         "node_modules/estree-walker": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/estree-walker/-/estree-walker-2.0.2.tgz",
             "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
             "license": "MIT"
         },
         "node_modules/esutils": {
             "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/esutils/-/esutils-2.0.3.tgz",
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "license": "BSD-2-Clause",
             "engines": {
@@ -3191,13 +3161,13 @@
         },
         "node_modules/eventemitter2": {
             "version": "6.4.7",
-            "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.7.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/eventemitter2/-/eventemitter2-6.4.7.tgz",
             "integrity": "sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==",
             "license": "MIT"
         },
         "node_modules/execa": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/execa/-/execa-4.1.0.tgz",
             "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
             "license": "MIT",
             "dependencies": {
@@ -3220,7 +3190,7 @@
         },
         "node_modules/executable": {
             "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/executable/-/executable-4.1.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/executable/-/executable-4.1.1.tgz",
             "integrity": "sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==",
             "license": "MIT",
             "dependencies": {
@@ -3232,13 +3202,13 @@
         },
         "node_modules/extend": {
             "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/extend/-/extend-3.0.2.tgz",
             "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
             "license": "MIT"
         },
         "node_modules/extract-zip": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/extract-zip/-/extract-zip-2.0.1.tgz",
             "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -3258,7 +3228,7 @@
         },
         "node_modules/extsprintf": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/extsprintf/-/extsprintf-1.3.0.tgz",
             "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
             "engines": [
                 "node >=0.6.0"
@@ -3267,7 +3237,7 @@
         },
         "node_modules/fast-glob": {
             "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/fast-glob/-/fast-glob-3.3.3.tgz",
             "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
             "license": "MIT",
             "dependencies": {
@@ -3283,7 +3253,7 @@
         },
         "node_modules/fastq": {
             "version": "1.20.1",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/fastq/-/fastq-1.20.1.tgz",
             "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
             "license": "ISC",
             "dependencies": {
@@ -3292,7 +3262,7 @@
         },
         "node_modules/fd-slicer": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/fd-slicer/-/fd-slicer-1.1.0.tgz",
             "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
             "license": "MIT",
             "dependencies": {
@@ -3301,7 +3271,7 @@
         },
         "node_modules/figures": {
             "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/figures/-/figures-3.2.0.tgz",
             "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
             "license": "MIT",
             "dependencies": {
@@ -3315,22 +3285,22 @@
             }
         },
         "node_modules/filing-cabinet": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-5.0.3.tgz",
-            "integrity": "sha512-PlPcMwVWg60NQkhvfoxZs4wEHjhlOO/y7OAm4sKM60o1Z9nttRY4mcdQxp/iZ+kg/Vv6Hw1OAaTbYVM9DA9pYg==",
+            "version": "5.2.0",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/filing-cabinet/-/filing-cabinet-5.2.0.tgz",
+            "integrity": "sha512-eNrCJGdYQY0tV+ACNesQ7vb2aMxD76NM7THayMn0Z5XBt1Tonr4vbVN+FbhHfekKGQG9O5UaciDDR7+dw8P9ZA==",
             "license": "MIT",
             "dependencies": {
                 "app-module-path": "^2.2.0",
                 "commander": "^12.1.0",
-                "enhanced-resolve": "^5.18.0",
+                "enhanced-resolve": "^5.20.0",
                 "module-definition": "^6.0.1",
-                "module-lookup-amd": "^9.0.3",
-                "resolve": "^1.22.10",
+                "module-lookup-amd": "^9.1.1",
+                "resolve": "^1.22.11",
                 "resolve-dependency-path": "^4.0.1",
                 "sass-lookup": "^6.1.0",
                 "stylus-lookup": "^6.1.0",
                 "tsconfig-paths": "^4.2.0",
-                "typescript": "^5.7.3"
+                "typescript": "^5.9.3"
             },
             "bin": {
                 "filing-cabinet": "bin/cli.js"
@@ -3341,7 +3311,7 @@
         },
         "node_modules/filing-cabinet/node_modules/commander": {
             "version": "12.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/commander/-/commander-12.1.0.tgz",
             "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
             "license": "MIT",
             "engines": {
@@ -3350,7 +3320,7 @@
         },
         "node_modules/fill-range": {
             "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/fill-range/-/fill-range-7.1.1.tgz",
             "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "license": "MIT",
             "dependencies": {
@@ -3361,9 +3331,9 @@
             }
         },
         "node_modules/find-cypress-specs": {
-            "version": "1.54.9",
-            "resolved": "https://registry.npmjs.org/find-cypress-specs/-/find-cypress-specs-1.54.9.tgz",
-            "integrity": "sha512-Wc4SDIUV3Gtb+PblVLMLHP6xkcUzqkTOPRkSott0hIYVGl714jDztr3Blgt4x0dq7AKXaKCFT+8Bngrnd/yNBw==",
+            "version": "1.54.12",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/find-cypress-specs/-/find-cypress-specs-1.54.12.tgz",
+            "integrity": "sha512-eTJi4qctSClNV5ZNveCq07D2cKdyreRXO6fPBx2zfknV+03WzJmxoOruNK7Ok41FvJNzf33wQyVygbO0XCvasQ==",
             "license": "MIT",
             "dependencies": {
                 "@actions/core": "^2.0.2",
@@ -3371,11 +3341,11 @@
                 "console.table": "^0.10.0",
                 "debug": "^4.3.3",
                 "find-test-names": "1.29.19",
-                "minimatch": "^5.1.4",
+                "minimatch": "^10.2.4",
                 "pluralize": "^8.0.0",
                 "require-and-forget": "^1.0.1",
                 "shelljs": "^0.10.0",
-                "spec-change": "^1.11.17",
+                "spec-change": "^1.11.21",
                 "tinyglobby": "^0.2.15",
                 "tsx": "^4.19.3"
             },
@@ -3388,7 +3358,7 @@
         },
         "node_modules/find-test-names": {
             "version": "1.29.19",
-            "resolved": "https://registry.npmjs.org/find-test-names/-/find-test-names-1.29.19.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/find-test-names/-/find-test-names-1.29.19.tgz",
             "integrity": "sha512-fSO2GXgOU6dH+FdffmRXYN/kLdnd8zkBGIZrKsmAdfLSFUUDLpDFF7+F/h+wjmjDWQmMgD8hPfJZR+igiEUQHQ==",
             "license": "MIT",
             "dependencies": {
@@ -3407,7 +3377,7 @@
         },
         "node_modules/find-up": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/find-up/-/find-up-5.0.0.tgz",
             "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
             "license": "MIT",
             "dependencies": {
@@ -3423,7 +3393,7 @@
         },
         "node_modules/find-up-simple": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/find-up-simple/-/find-up-simple-1.0.1.tgz",
             "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
             "license": "MIT",
             "engines": {
@@ -3435,7 +3405,7 @@
         },
         "node_modules/flat": {
             "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/flat/-/flat-5.0.2.tgz",
             "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
             "license": "BSD-3-Clause",
             "bin": {
@@ -3444,7 +3414,7 @@
         },
         "node_modules/for-each": {
             "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/for-each/-/for-each-0.3.5.tgz",
             "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
             "license": "MIT",
             "dependencies": {
@@ -3459,7 +3429,7 @@
         },
         "node_modules/foreground-child": {
             "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/foreground-child/-/foreground-child-3.3.1.tgz",
             "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
             "license": "ISC",
             "dependencies": {
@@ -3475,7 +3445,7 @@
         },
         "node_modules/foreground-child/node_modules/signal-exit": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/signal-exit/-/signal-exit-4.1.0.tgz",
             "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
             "license": "ISC",
             "engines": {
@@ -3487,7 +3457,7 @@
         },
         "node_modules/forever-agent": {
             "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/forever-agent/-/forever-agent-0.6.1.tgz",
             "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
             "license": "Apache-2.0",
             "engines": {
@@ -3496,7 +3466,7 @@
         },
         "node_modules/form-data": {
             "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/form-data/-/form-data-4.0.5.tgz",
             "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
             "license": "MIT",
             "dependencies": {
@@ -3512,14 +3482,13 @@
         },
         "node_modules/fp-ts": {
             "version": "2.16.11",
-            "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.16.11.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/fp-ts/-/fp-ts-2.16.11.tgz",
             "integrity": "sha512-LaI+KaX2NFkfn1ZGHoKCmcfv7yrZsC3b8NtWsTVQeHkq4F27vI5igUuO53sxqDEa2gNQMHFPmpojDw/1zmUK7w==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/fs-extra": {
             "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/fs-extra/-/fs-extra-9.1.0.tgz",
             "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
             "license": "MIT",
             "dependencies": {
@@ -3532,15 +3501,9 @@
                 "node": ">=10"
             }
         },
-        "node_modules/fs.realpath": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-            "license": "ISC"
-        },
         "node_modules/fsevents": {
             "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/fsevents/-/fsevents-2.3.3.tgz",
             "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
             "hasInstallScript": true,
             "license": "MIT",
@@ -3554,7 +3517,7 @@
         },
         "node_modules/function-bind": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/function-bind/-/function-bind-1.1.2.tgz",
             "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
             "license": "MIT",
             "funding": {
@@ -3563,7 +3526,7 @@
         },
         "node_modules/functions-have-names": {
             "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/functions-have-names/-/functions-have-names-1.2.3.tgz",
             "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
             "license": "MIT",
             "funding": {
@@ -3572,16 +3535,17 @@
         },
         "node_modules/gensync": {
             "version": "1.0.0-beta.2",
-            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/gensync/-/gensync-1.0.0-beta.2.tgz",
             "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/get-amd-module-type": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/get-amd-module-type/-/get-amd-module-type-6.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/get-amd-module-type/-/get-amd-module-type-6.0.1.tgz",
             "integrity": "sha512-MtjsmYiCXcYDDrGqtNbeIYdAl85n+5mSv2r3FbzER/YV3ZILw4HNNIw34HuV5pyl0jzs6GFYU1VHVEefhgcNHQ==",
             "license": "MIT",
             "dependencies": {
@@ -3594,7 +3558,7 @@
         },
         "node_modules/get-caller-file": {
             "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
             "license": "ISC",
             "engines": {
@@ -3603,7 +3567,7 @@
         },
         "node_modules/get-intrinsic": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
             "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
             "license": "MIT",
             "dependencies": {
@@ -3627,13 +3591,13 @@
         },
         "node_modules/get-own-enumerable-property-symbols": {
             "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
             "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
             "license": "ISC"
         },
         "node_modules/get-proto": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/get-proto/-/get-proto-1.0.1.tgz",
             "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
             "license": "MIT",
             "dependencies": {
@@ -3646,7 +3610,7 @@
         },
         "node_modules/get-stream": {
             "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/get-stream/-/get-stream-5.2.0.tgz",
             "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
             "license": "MIT",
             "dependencies": {
@@ -3660,9 +3624,9 @@
             }
         },
         "node_modules/get-tsconfig": {
-            "version": "4.13.0",
-            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
-            "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
+            "version": "4.13.7",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+            "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
             "license": "MIT",
             "dependencies": {
                 "resolve-pkg-maps": "^1.0.0"
@@ -3673,7 +3637,7 @@
         },
         "node_modules/getpass": {
             "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
             "license": "MIT",
             "dependencies": {
@@ -3681,17 +3645,17 @@
             }
         },
         "node_modules/glob": {
-            "version": "13.0.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
-            "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
+            "version": "13.0.6",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "minimatch": "^10.1.1",
-                "minipass": "^7.1.2",
-                "path-scurry": "^2.0.0"
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
             },
             "engines": {
-                "node": "20 || >=22"
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -3699,7 +3663,7 @@
         },
         "node_modules/glob-parent": {
             "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
             "license": "ISC",
             "dependencies": {
@@ -3709,24 +3673,9 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/glob/node_modules/minimatch": {
-            "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-            "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "@isaacs/brace-expansion": "^5.0.0"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/global-dirs": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/global-dirs/-/global-dirs-3.0.1.tgz",
             "integrity": "sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==",
             "license": "MIT",
             "dependencies": {
@@ -3741,7 +3690,7 @@
         },
         "node_modules/gonzales-pe": {
             "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.3.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/gonzales-pe/-/gonzales-pe-4.3.0.tgz",
             "integrity": "sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==",
             "license": "MIT",
             "dependencies": {
@@ -3756,7 +3705,7 @@
         },
         "node_modules/gopd": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/gopd/-/gopd-1.2.0.tgz",
             "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
             "license": "MIT",
             "engines": {
@@ -3768,13 +3717,13 @@
         },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/graceful-fs/-/graceful-fs-4.2.11.tgz",
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
             "license": "ISC"
         },
         "node_modules/has-ansi": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-4.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/has-ansi/-/has-ansi-4.0.1.tgz",
             "integrity": "sha512-Qr4RtTm30xvEdqUXbSBVWDu+PrTokJOwe/FU+VdfJPk+MXAPoeOzKpRyrDTnZIJwAkQ4oBLTU53nu0HrkF/Z2A==",
             "license": "MIT",
             "dependencies": {
@@ -3786,7 +3735,7 @@
         },
         "node_modules/has-bigints": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/has-bigints/-/has-bigints-1.1.0.tgz",
             "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
             "license": "MIT",
             "engines": {
@@ -3798,7 +3747,7 @@
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
             "license": "MIT",
             "engines": {
@@ -3807,7 +3756,7 @@
         },
         "node_modules/has-property-descriptors": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
             "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
             "license": "MIT",
             "dependencies": {
@@ -3819,7 +3768,7 @@
         },
         "node_modules/has-symbols": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/has-symbols/-/has-symbols-1.1.0.tgz",
             "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
             "license": "MIT",
             "engines": {
@@ -3831,7 +3780,7 @@
         },
         "node_modules/has-tostringtag": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
             "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
             "license": "MIT",
             "dependencies": {
@@ -3846,7 +3795,7 @@
         },
         "node_modules/hasha": {
             "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/hasha/-/hasha-5.2.2.tgz",
             "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
             "license": "MIT",
             "dependencies": {
@@ -3862,7 +3811,7 @@
         },
         "node_modules/hasha/node_modules/type-fest": {
             "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/type-fest/-/type-fest-0.8.1.tgz",
             "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
             "license": "(MIT OR CC0-1.0)",
             "engines": {
@@ -3871,7 +3820,7 @@
         },
         "node_modules/hasown": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/hasown/-/hasown-2.0.2.tgz",
             "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
             "license": "MIT",
             "dependencies": {
@@ -3883,7 +3832,7 @@
         },
         "node_modules/he": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/he/-/he-1.2.0.tgz",
             "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
             "license": "MIT",
             "bin": {
@@ -3892,7 +3841,7 @@
         },
         "node_modules/hosted-git-info": {
             "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
             "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
             "license": "ISC",
             "dependencies": {
@@ -3903,9 +3852,9 @@
             }
         },
         "node_modules/hosted-git-info/node_modules/lru-cache": {
-            "version": "11.2.5",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
-            "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+            "version": "11.2.7",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/lru-cache/-/lru-cache-11.2.7.tgz",
+            "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
@@ -3913,7 +3862,7 @@
         },
         "node_modules/http-signature": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.4.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/http-signature/-/http-signature-1.4.0.tgz",
             "integrity": "sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==",
             "license": "MIT",
             "dependencies": {
@@ -3927,7 +3876,7 @@
         },
         "node_modules/human-signals": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/human-signals/-/human-signals-1.1.1.tgz",
             "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
             "license": "Apache-2.0",
             "engines": {
@@ -3936,7 +3885,7 @@
         },
         "node_modules/ieee754": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/ieee754/-/ieee754-1.2.1.tgz",
             "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
             "funding": [
                 {
@@ -3956,7 +3905,7 @@
         },
         "node_modules/import-fresh": {
             "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/import-fresh/-/import-fresh-3.3.1.tgz",
             "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
             "license": "MIT",
             "dependencies": {
@@ -3972,7 +3921,7 @@
         },
         "node_modules/indent-string": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/indent-string/-/indent-string-4.0.0.tgz",
             "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
             "license": "MIT",
             "engines": {
@@ -3981,7 +3930,7 @@
         },
         "node_modules/index-to-position": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/index-to-position/-/index-to-position-1.2.0.tgz",
             "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
             "license": "MIT",
             "engines": {
@@ -3991,26 +3940,9 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/inflight": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-            "license": "ISC",
-            "dependencies": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-            }
-        },
-        "node_modules/inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "license": "ISC"
-        },
         "node_modules/ini": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/ini/-/ini-2.0.0.tgz",
             "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
             "license": "ISC",
             "engines": {
@@ -4019,7 +3951,7 @@
         },
         "node_modules/internal-slot": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/internal-slot/-/internal-slot-1.1.0.tgz",
             "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
             "license": "MIT",
             "dependencies": {
@@ -4033,7 +3965,7 @@
         },
         "node_modules/io-ts": {
             "version": "2.2.22",
-            "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.22.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/io-ts/-/io-ts-2.2.22.tgz",
             "integrity": "sha512-FHCCztTkHoV9mdBsHpocLpdTAfh956ZQcIkWQxxS0U5HT53vtrcuYdQneEJKH6xILaLNzXVl2Cvwtoy8XNN0AA==",
             "license": "MIT",
             "peerDependencies": {
@@ -4042,7 +3974,7 @@
         },
         "node_modules/is-arguments": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/is-arguments/-/is-arguments-1.2.0.tgz",
             "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
             "license": "MIT",
             "dependencies": {
@@ -4058,7 +3990,7 @@
         },
         "node_modules/is-array-buffer": {
             "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
             "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
             "license": "MIT",
             "dependencies": {
@@ -4075,13 +4007,13 @@
         },
         "node_modules/is-arrayish": {
             "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/is-arrayish/-/is-arrayish-0.2.1.tgz",
             "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
             "license": "MIT"
         },
         "node_modules/is-bigint": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/is-bigint/-/is-bigint-1.1.0.tgz",
             "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
             "license": "MIT",
             "dependencies": {
@@ -4096,7 +4028,7 @@
         },
         "node_modules/is-boolean-object": {
             "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
             "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
             "license": "MIT",
             "dependencies": {
@@ -4112,7 +4044,7 @@
         },
         "node_modules/is-callable": {
             "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/is-callable/-/is-callable-1.2.7.tgz",
             "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
             "license": "MIT",
             "engines": {
@@ -4124,7 +4056,7 @@
         },
         "node_modules/is-core-module": {
             "version": "2.16.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/is-core-module/-/is-core-module-2.16.1.tgz",
             "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
             "license": "MIT",
             "dependencies": {
@@ -4139,7 +4071,7 @@
         },
         "node_modules/is-date-object": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/is-date-object/-/is-date-object-1.1.0.tgz",
             "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
             "license": "MIT",
             "dependencies": {
@@ -4155,7 +4087,7 @@
         },
         "node_modules/is-extglob": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
             "license": "MIT",
             "engines": {
@@ -4164,7 +4096,7 @@
         },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
             "license": "MIT",
             "engines": {
@@ -4173,7 +4105,7 @@
         },
         "node_modules/is-glob": {
             "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
             "license": "MIT",
             "dependencies": {
@@ -4185,7 +4117,7 @@
         },
         "node_modules/is-installed-globally": {
             "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
             "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
             "license": "MIT",
             "dependencies": {
@@ -4201,7 +4133,7 @@
         },
         "node_modules/is-map": {
             "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/is-map/-/is-map-2.0.3.tgz",
             "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
             "license": "MIT",
             "engines": {
@@ -4213,7 +4145,7 @@
         },
         "node_modules/is-number": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "license": "MIT",
             "engines": {
@@ -4222,7 +4154,7 @@
         },
         "node_modules/is-number-object": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/is-number-object/-/is-number-object-1.1.1.tgz",
             "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
             "license": "MIT",
             "dependencies": {
@@ -4238,7 +4170,7 @@
         },
         "node_modules/is-obj": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/is-obj/-/is-obj-1.0.1.tgz",
             "integrity": "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==",
             "license": "MIT",
             "engines": {
@@ -4247,7 +4179,7 @@
         },
         "node_modules/is-path-inside": {
             "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/is-path-inside/-/is-path-inside-3.0.3.tgz",
             "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
             "license": "MIT",
             "engines": {
@@ -4256,7 +4188,7 @@
         },
         "node_modules/is-plain-obj": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
             "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
             "license": "MIT",
             "engines": {
@@ -4265,7 +4197,7 @@
         },
         "node_modules/is-regex": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/is-regex/-/is-regex-1.2.1.tgz",
             "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
             "license": "MIT",
             "dependencies": {
@@ -4283,7 +4215,7 @@
         },
         "node_modules/is-regexp": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/is-regexp/-/is-regexp-1.0.0.tgz",
             "integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
             "license": "MIT",
             "engines": {
@@ -4292,7 +4224,7 @@
         },
         "node_modules/is-set": {
             "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/is-set/-/is-set-2.0.3.tgz",
             "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
             "license": "MIT",
             "engines": {
@@ -4304,7 +4236,7 @@
         },
         "node_modules/is-shared-array-buffer": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
             "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
             "license": "MIT",
             "dependencies": {
@@ -4319,7 +4251,7 @@
         },
         "node_modules/is-stream": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/is-stream/-/is-stream-2.0.1.tgz",
             "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
             "license": "MIT",
             "engines": {
@@ -4331,7 +4263,7 @@
         },
         "node_modules/is-string": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/is-string/-/is-string-1.1.1.tgz",
             "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
             "license": "MIT",
             "dependencies": {
@@ -4347,7 +4279,7 @@
         },
         "node_modules/is-symbol": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/is-symbol/-/is-symbol-1.1.1.tgz",
             "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
             "license": "MIT",
             "dependencies": {
@@ -4364,13 +4296,13 @@
         },
         "node_modules/is-typedarray": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/is-typedarray/-/is-typedarray-1.0.0.tgz",
             "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
             "license": "MIT"
         },
         "node_modules/is-unicode-supported": {
             "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
             "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
             "license": "MIT",
             "engines": {
@@ -4382,13 +4314,13 @@
         },
         "node_modules/is-url": {
             "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/is-url/-/is-url-1.2.4.tgz",
             "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
             "license": "MIT"
         },
         "node_modules/is-url-superb": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-4.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/is-url-superb/-/is-url-superb-4.0.0.tgz",
             "integrity": "sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==",
             "license": "MIT",
             "engines": {
@@ -4400,7 +4332,7 @@
         },
         "node_modules/is-weakmap": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/is-weakmap/-/is-weakmap-2.0.2.tgz",
             "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
             "license": "MIT",
             "engines": {
@@ -4412,7 +4344,7 @@
         },
         "node_modules/is-weakset": {
             "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/is-weakset/-/is-weakset-2.0.4.tgz",
             "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
             "license": "MIT",
             "dependencies": {
@@ -4428,25 +4360,25 @@
         },
         "node_modules/isarray": {
             "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/isarray/-/isarray-2.0.5.tgz",
             "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
             "license": "MIT"
         },
         "node_modules/isexe": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "license": "ISC"
         },
         "node_modules/isstream": {
             "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/isstream/-/isstream-0.1.2.tgz",
             "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
             "license": "MIT"
         },
         "node_modules/jackspeak": {
             "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/jackspeak/-/jackspeak-3.4.3.tgz",
             "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -4461,13 +4393,13 @@
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
             "license": "MIT"
         },
         "node_modules/js-yaml": {
             "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/js-yaml/-/js-yaml-4.1.1.tgz",
             "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
             "license": "MIT",
             "dependencies": {
@@ -4479,15 +4411,16 @@
         },
         "node_modules/jsbn": {
             "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/jsbn/-/jsbn-0.1.1.tgz",
             "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
             "license": "MIT"
         },
         "node_modules/jsesc": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/jsesc/-/jsesc-3.1.0.tgz",
             "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "jsesc": "bin/jsesc"
             },
@@ -4497,25 +4430,25 @@
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
             "license": "MIT"
         },
         "node_modules/json-schema": {
             "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/json-schema/-/json-schema-0.4.0.tgz",
             "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
             "license": "(AFL-2.1 OR BSD-3-Clause)"
         },
         "node_modules/json-stringify-safe": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
             "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
             "license": "ISC"
         },
         "node_modules/json5": {
             "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/json5/-/json5-2.2.3.tgz",
             "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
             "license": "MIT",
             "bin": {
@@ -4527,7 +4460,7 @@
         },
         "node_modules/jsonfile": {
             "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/jsonfile/-/jsonfile-6.2.0.tgz",
             "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
             "license": "MIT",
             "dependencies": {
@@ -4539,7 +4472,7 @@
         },
         "node_modules/jsprim": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/jsprim/-/jsprim-2.0.2.tgz",
             "integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
             "engines": [
                 "node >=0.6.0"
@@ -4554,7 +4487,7 @@
         },
         "node_modules/knuth-shuffle-seeded": {
             "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/knuth-shuffle-seeded/-/knuth-shuffle-seeded-1.0.6.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/knuth-shuffle-seeded/-/knuth-shuffle-seeded-1.0.6.tgz",
             "integrity": "sha512-9pFH0SplrfyKyojCLxZfMcvkhf5hH0d+UwR9nTVJ/DDQJGuzcXjTwB7TP7sDfehSudlGGaOLblmEWqv04ERVWg==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -4563,7 +4496,7 @@
         },
         "node_modules/lazy-ass": {
             "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-2.0.3.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/lazy-ass/-/lazy-ass-2.0.3.tgz",
             "integrity": "sha512-/O3/DoQmI1XAhklDvF1dAjFf/epE8u3lzOZegQfLZ8G7Ud5bTRSZiFOpukHCu6jODrCA4gtIdwUCC7htxcDACA==",
             "license": "MIT",
             "engines": {
@@ -4572,13 +4505,13 @@
         },
         "node_modules/lines-and-columns": {
             "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
             "license": "MIT"
         },
         "node_modules/listr2": {
             "version": "3.14.0",
-            "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.14.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/listr2/-/listr2-3.14.0.tgz",
             "integrity": "sha512-TyWI8G99GX9GjE54cJ+RrNMcIFBfwMPxc3XTFiAYGN4s10hWROGtOg7+O6u6LE3mNkyld7RSLE6nrKBvTfcs3g==",
             "license": "MIT",
             "dependencies": {
@@ -4605,7 +4538,7 @@
         },
         "node_modules/locate-path": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/locate-path/-/locate-path-6.0.0.tgz",
             "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
             "license": "MIT",
             "dependencies": {
@@ -4620,37 +4553,37 @@
         },
         "node_modules/lodash": {
             "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/lodash/-/lodash-4.17.23.tgz",
             "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
             "license": "MIT"
         },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "license": "MIT"
         },
         "node_modules/lodash.mergewith": {
             "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
             "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
             "license": "MIT"
         },
         "node_modules/lodash.once": {
             "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/lodash.once/-/lodash.once-4.1.1.tgz",
             "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
             "license": "MIT"
         },
         "node_modules/lodash.sortby": {
             "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
             "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
             "license": "MIT"
         },
         "node_modules/log-symbols": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/log-symbols/-/log-symbols-4.1.0.tgz",
             "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
             "license": "MIT",
             "dependencies": {
@@ -4666,7 +4599,7 @@
         },
         "node_modules/log-update": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/log-update/-/log-update-4.0.0.tgz",
             "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
             "license": "MIT",
             "dependencies": {
@@ -4682,24 +4615,9 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/log-update/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "license": "MIT",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
         "node_modules/log-update/node_modules/slice-ansi": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/slice-ansi/-/slice-ansi-4.0.0.tgz",
             "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
             "license": "MIT",
             "dependencies": {
@@ -4716,7 +4634,7 @@
         },
         "node_modules/log-update/node_modules/wrap-ansi": {
             "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
             "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
             "license": "MIT",
             "dependencies": {
@@ -4730,7 +4648,7 @@
         },
         "node_modules/lower-case": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/lower-case/-/lower-case-2.0.2.tgz",
             "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
             "license": "MIT",
             "dependencies": {
@@ -4739,16 +4657,17 @@
         },
         "node_modules/lru-cache": {
             "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/lru-cache/-/lru-cache-5.1.1.tgz",
             "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "yallist": "^3.0.2"
             }
         },
         "node_modules/luxon": {
             "version": "3.7.2",
-            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/luxon/-/luxon-3.7.2.tgz",
             "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
             "license": "MIT",
             "engines": {
@@ -4757,7 +4676,7 @@
         },
         "node_modules/magic-string": {
             "version": "0.30.21",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/magic-string/-/magic-string-0.30.21.tgz",
             "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
             "license": "MIT",
             "dependencies": {
@@ -4766,7 +4685,7 @@
         },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
             "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
             "license": "MIT",
             "engines": {
@@ -4775,13 +4694,13 @@
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/merge-stream/-/merge-stream-2.0.0.tgz",
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
             "license": "MIT"
         },
         "node_modules/merge2": {
             "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
             "license": "MIT",
             "engines": {
@@ -4790,7 +4709,7 @@
         },
         "node_modules/micromatch": {
             "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/micromatch/-/micromatch-4.0.8.tgz",
             "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "license": "MIT",
             "dependencies": {
@@ -4803,7 +4722,7 @@
         },
         "node_modules/mime": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/mime/-/mime-3.0.0.tgz",
             "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
             "license": "MIT",
             "bin": {
@@ -4815,7 +4734,7 @@
         },
         "node_modules/mime-db": {
             "version": "1.52.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/mime-db/-/mime-db-1.52.0.tgz",
             "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
             "license": "MIT",
             "engines": {
@@ -4824,7 +4743,7 @@
         },
         "node_modules/mime-types": {
             "version": "2.1.35",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/mime-types/-/mime-types-2.1.35.tgz",
             "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
             "license": "MIT",
             "dependencies": {
@@ -4836,7 +4755,7 @@
         },
         "node_modules/mimic-fn": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/mimic-fn/-/mimic-fn-2.1.0.tgz",
             "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
             "license": "MIT",
             "engines": {
@@ -4844,20 +4763,23 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-            "license": "ISC",
+            "version": "10.2.4",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/minimatch/-/minimatch-10.2.4.tgz",
+            "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^5.0.2"
             },
             "engines": {
-                "node": ">=10"
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/minimist": {
             "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/minimist/-/minimist-1.2.8.tgz",
             "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
             "license": "MIT",
             "funding": {
@@ -4865,17 +4787,17 @@
             }
         },
         "node_modules/minipass": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-            "license": "ISC",
+            "version": "7.1.3",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/minipass/-/minipass-7.1.3.tgz",
+            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+            "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=16 || 14 >=14.17"
             }
         },
         "node_modules/mkdirp": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/mkdirp/-/mkdirp-3.0.1.tgz",
             "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
             "license": "MIT",
             "bin": {
@@ -4890,7 +4812,7 @@
         },
         "node_modules/mocha": {
             "version": "11.7.5",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/mocha/-/mocha-11.7.5.tgz",
             "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
             "license": "MIT",
             "dependencies": {
@@ -4924,9 +4846,24 @@
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
+        "node_modules/mocha/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "license": "MIT"
+        },
+        "node_modules/mocha/node_modules/brace-expansion": {
+            "version": "2.0.2",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
         "node_modules/mocha/node_modules/diff": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/diff/-/diff-7.0.0.tgz",
             "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
             "license": "BSD-3-Clause",
             "engines": {
@@ -4935,7 +4872,7 @@
         },
         "node_modules/mocha/node_modules/escape-string-regexp": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
             "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
             "license": "MIT",
             "engines": {
@@ -4947,8 +4884,9 @@
         },
         "node_modules/mocha/node_modules/glob": {
             "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/glob/-/glob-10.5.0.tgz",
             "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "license": "ISC",
             "dependencies": {
                 "foreground-child": "^3.1.0",
@@ -4967,17 +4905,17 @@
         },
         "node_modules/mocha/node_modules/lru-cache": {
             "version": "10.4.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/lru-cache/-/lru-cache-10.4.3.tgz",
             "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
             "license": "ISC"
         },
         "node_modules/mocha/node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "version": "9.0.9",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -4988,7 +4926,7 @@
         },
         "node_modules/mocha/node_modules/path-scurry": {
             "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/path-scurry/-/path-scurry-1.11.1.tgz",
             "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -5004,7 +4942,7 @@
         },
         "node_modules/module-definition": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/module-definition/-/module-definition-6.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/module-definition/-/module-definition-6.0.1.tgz",
             "integrity": "sha512-FeVc50FTfVVQnolk/WQT8MX+2WVcDnTGiq6Wo+/+lJ2ET1bRVi3HG3YlJUfqagNMc/kUlFSoR96AJkxGpKz13g==",
             "license": "MIT",
             "dependencies": {
@@ -5019,14 +4957,13 @@
             }
         },
         "node_modules/module-lookup-amd": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/module-lookup-amd/-/module-lookup-amd-9.0.5.tgz",
-            "integrity": "sha512-Rs5FVpVcBYRHPLuhHOjgbRhosaQYLtEo3JIeDIbmNo7mSssi1CTzwMh8v36gAzpbzLGXI9wB/yHh+5+3fY1QVw==",
+            "version": "9.1.1",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/module-lookup-amd/-/module-lookup-amd-9.1.1.tgz",
+            "integrity": "sha512-JzXhQvud8K3yT9l24XTDMXMQ4/LD9a9oXBcbLP0ubdvBpVrGFsybm5+2PDIl0negUYP1l88fCgjQzoMMg247+Q==",
             "license": "MIT",
             "dependencies": {
                 "commander": "^12.1.0",
-                "glob": "^7.2.3",
-                "requirejs": "^2.3.7",
+                "requirejs": "^2.3.8",
                 "requirejs-config-file": "^4.0.0"
             },
             "bin": {
@@ -5036,67 +4973,24 @@
                 "node": ">=18"
             }
         },
-        "node_modules/module-lookup-amd/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
         "node_modules/module-lookup-amd/node_modules/commander": {
             "version": "12.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/commander/-/commander-12.1.0.tgz",
             "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
             }
         },
-        "node_modules/module-lookup-amd/node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/module-lookup-amd/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/ms": {
             "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "license": "MIT"
         },
         "node_modules/mz": {
             "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/mz/-/mz-2.7.0.tgz",
             "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
             "license": "MIT",
             "dependencies": {
@@ -5107,7 +5001,7 @@
         },
         "node_modules/nanoid": {
             "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/nanoid/-/nanoid-3.3.11.tgz",
             "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
             "funding": [
                 {
@@ -5125,7 +5019,7 @@
         },
         "node_modules/no-case": {
             "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/no-case/-/no-case-3.0.4.tgz",
             "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
             "license": "MIT",
             "dependencies": {
@@ -5134,14 +5028,15 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.27",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-            "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
-            "license": "MIT"
+            "version": "2.0.36",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/node-releases/-/node-releases-2.0.36.tgz",
+            "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/node-source-walk": {
             "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-7.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/node-source-walk/-/node-source-walk-7.0.1.tgz",
             "integrity": "sha512-3VW/8JpPqPvnJvseXowjZcirPisssnBuDikk6JIZ8jQzF7KJQX52iPFX4RYYxLycYH7IbMRSPUOga/esVjy5Yg==",
             "license": "MIT",
             "dependencies": {
@@ -5153,7 +5048,7 @@
         },
         "node_modules/normalize-package-data": {
             "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-8.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/normalize-package-data/-/normalize-package-data-8.0.0.tgz",
             "integrity": "sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==",
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -5167,7 +5062,7 @@
         },
         "node_modules/npm-run-path": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/npm-run-path/-/npm-run-path-4.0.1.tgz",
             "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
             "license": "MIT",
             "dependencies": {
@@ -5179,7 +5074,7 @@
         },
         "node_modules/object-assign": {
             "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
             "license": "MIT",
             "engines": {
@@ -5188,7 +5083,7 @@
         },
         "node_modules/object-inspect": {
             "version": "1.13.4",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/object-inspect/-/object-inspect-1.13.4.tgz",
             "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
             "license": "MIT",
             "engines": {
@@ -5200,7 +5095,7 @@
         },
         "node_modules/object-is": {
             "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/object-is/-/object-is-1.1.6.tgz",
             "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
             "license": "MIT",
             "dependencies": {
@@ -5216,7 +5111,7 @@
         },
         "node_modules/object-keys": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/object-keys/-/object-keys-1.1.1.tgz",
             "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
             "license": "MIT",
             "engines": {
@@ -5225,7 +5120,7 @@
         },
         "node_modules/object.assign": {
             "version": "4.1.7",
-            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/object.assign/-/object.assign-4.1.7.tgz",
             "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
             "license": "MIT",
             "dependencies": {
@@ -5245,7 +5140,7 @@
         },
         "node_modules/once": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
             "license": "ISC",
             "dependencies": {
@@ -5254,7 +5149,7 @@
         },
         "node_modules/onetime": {
             "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/onetime/-/onetime-5.1.2.tgz",
             "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
             "license": "MIT",
             "dependencies": {
@@ -5269,13 +5164,13 @@
         },
         "node_modules/ospath": {
             "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/ospath/-/ospath-1.2.2.tgz",
             "integrity": "sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==",
             "license": "MIT"
         },
         "node_modules/p-limit": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/p-limit/-/p-limit-3.1.0.tgz",
             "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
             "license": "MIT",
             "dependencies": {
@@ -5290,7 +5185,7 @@
         },
         "node_modules/p-locate": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/p-locate/-/p-locate-5.0.0.tgz",
             "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
             "license": "MIT",
             "dependencies": {
@@ -5305,7 +5200,7 @@
         },
         "node_modules/p-map": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/p-map/-/p-map-4.0.0.tgz",
             "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
             "license": "MIT",
             "dependencies": {
@@ -5320,13 +5215,13 @@
         },
         "node_modules/package-json-from-dist": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
             "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
             "license": "BlueOak-1.0.0"
         },
         "node_modules/pad-right": {
             "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/pad-right/-/pad-right-0.2.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/pad-right/-/pad-right-0.2.2.tgz",
             "integrity": "sha512-4cy8M95ioIGolCoMmm2cMntGR1lPLEbOMzOKu8bzjuJP6JpzEMQcDHmh7hHLYGgob+nKe1YHFMaG4V59HQa89g==",
             "license": "MIT",
             "dependencies": {
@@ -5338,7 +5233,7 @@
         },
         "node_modules/parent-module": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/parent-module/-/parent-module-1.0.1.tgz",
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
             "license": "MIT",
             "dependencies": {
@@ -5350,7 +5245,7 @@
         },
         "node_modules/parse-json": {
             "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/parse-json/-/parse-json-5.2.0.tgz",
             "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
             "license": "MIT",
             "dependencies": {
@@ -5368,31 +5263,22 @@
         },
         "node_modules/path-browserify": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/path-browserify/-/path-browserify-1.0.1.tgz",
             "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
             "license": "MIT"
         },
         "node_modules/path-exists": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/path-exists/-/path-exists-4.0.0.tgz",
             "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
             "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
-        "node_modules/path-is-absolute": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/path-key": {
             "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
             "license": "MIT",
             "engines": {
@@ -5401,30 +5287,30 @@
         },
         "node_modules/path-parse": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "license": "MIT"
         },
         "node_modules/path-scurry": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
-            "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+            "version": "2.0.2",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/path-scurry/-/path-scurry-2.0.2.tgz",
+            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "lru-cache": "^11.0.0",
                 "minipass": "^7.1.2"
             },
             "engines": {
-                "node": "20 || >=22"
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/path-scurry/node_modules/lru-cache": {
-            "version": "11.2.5",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
-            "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+            "version": "11.2.7",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/lru-cache/-/lru-cache-11.2.7.tgz",
+            "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
@@ -5432,26 +5318,26 @@
         },
         "node_modules/pend": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/pend/-/pend-1.2.0.tgz",
             "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
             "license": "MIT"
         },
         "node_modules/performance-now": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/performance-now/-/performance-now-2.1.0.tgz",
             "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
             "license": "MIT"
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/picocolors/-/picocolors-1.1.1.tgz",
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "license": "MIT",
             "engines": {
                 "node": ">=8.6"
@@ -5462,7 +5348,7 @@
         },
         "node_modules/pify": {
             "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/pify/-/pify-2.3.0.tgz",
             "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
             "license": "MIT",
             "engines": {
@@ -5471,7 +5357,7 @@
         },
         "node_modules/pluralize": {
             "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/pluralize/-/pluralize-8.0.0.tgz",
             "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
             "license": "MIT",
             "engines": {
@@ -5480,7 +5366,7 @@
         },
         "node_modules/possible-typed-array-names": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
             "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
             "license": "MIT",
             "engines": {
@@ -5488,9 +5374,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.6",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-            "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+            "version": "8.5.8",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/postcss/-/postcss-8.5.8.tgz",
+            "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -5506,7 +5392,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -5518,7 +5403,7 @@
         },
         "node_modules/postcss-values-parser": {
             "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-6.0.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/postcss-values-parser/-/postcss-values-parser-6.0.2.tgz",
             "integrity": "sha512-YLJpK0N1brcNJrs9WatuJFtHaV9q5aAOj+S4DI5S7jgHlRfm0PIbDCAFRYMQD5SHq7Fy6xsDhyutgS0QOAs0qw==",
             "license": "MPL-2.0",
             "dependencies": {
@@ -5535,7 +5420,7 @@
         },
         "node_modules/precinct": {
             "version": "12.2.0",
-            "resolved": "https://registry.npmjs.org/precinct/-/precinct-12.2.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/precinct/-/precinct-12.2.0.tgz",
             "integrity": "sha512-NFBMuwIfaJ4SocE9YXPU/n4AcNSoFMVFjP72nvl3cx69j/ke61/hPOWFREVxLkFhhEGnA8ZuVfTqJBa+PK3b5w==",
             "license": "MIT",
             "dependencies": {
@@ -5564,7 +5449,7 @@
         },
         "node_modules/precinct/node_modules/commander": {
             "version": "12.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/commander/-/commander-12.1.0.tgz",
             "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
             "license": "MIT",
             "engines": {
@@ -5573,7 +5458,7 @@
         },
         "node_modules/pretty-bytes": {
             "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
             "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
             "license": "MIT",
             "engines": {
@@ -5585,7 +5470,7 @@
         },
         "node_modules/process": {
             "version": "0.11.10",
-            "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/process/-/process-0.11.10.tgz",
             "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
             "license": "MIT",
             "engines": {
@@ -5594,7 +5479,7 @@
         },
         "node_modules/progress": {
             "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/progress/-/progress-2.0.3.tgz",
             "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
             "license": "MIT",
             "engines": {
@@ -5603,20 +5488,20 @@
         },
         "node_modules/property-expr": {
             "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/property-expr/-/property-expr-2.0.6.tgz",
             "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
             "license": "MIT"
         },
         "node_modules/proxy-from-env": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
             "integrity": "sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==",
             "license": "MIT"
         },
         "node_modules/pump": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-            "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+            "version": "3.0.4",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/pump/-/pump-3.0.4.tgz",
+            "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
             "license": "MIT",
             "dependencies": {
                 "end-of-stream": "^1.1.0",
@@ -5624,9 +5509,9 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.14.1",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-            "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+            "version": "6.14.2",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/qs/-/qs-6.14.2.tgz",
+            "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "side-channel": "^1.1.0"
@@ -5640,7 +5525,7 @@
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/queue-microtask/-/queue-microtask-1.2.3.tgz",
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "funding": [
                 {
@@ -5660,13 +5545,13 @@
         },
         "node_modules/quote-unquote": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/quote-unquote/-/quote-unquote-1.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/quote-unquote/-/quote-unquote-1.0.0.tgz",
             "integrity": "sha512-twwRO/ilhlG/FIgYeKGFqyHhoEhqgnKVkcmqMKi2r524gz3ZbDTcyFt38E9xjJI2vT+KbRNHVbnJ/e0I25Azwg==",
             "license": "MIT"
         },
         "node_modules/randombytes": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/randombytes/-/randombytes-2.1.0.tgz",
             "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
             "license": "MIT",
             "dependencies": {
@@ -5675,7 +5560,7 @@
         },
         "node_modules/read-package-up": {
             "version": "12.0.0",
-            "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-12.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/read-package-up/-/read-package-up-12.0.0.tgz",
             "integrity": "sha512-Q5hMVBYur/eQNWDdbF4/Wqqr9Bjvtrw2kjGxxBbKLbx8bVCL8gcArjTy8zDUuLGQicftpMuU0riQNcAsbtOVsw==",
             "license": "MIT",
             "dependencies": {
@@ -5691,9 +5576,9 @@
             }
         },
         "node_modules/read-package-up/node_modules/type-fest": {
-            "version": "5.4.2",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.2.tgz",
-            "integrity": "sha512-FLEenlVYf7Zcd34ISMLo3ZzRE1gRjY1nMDTp+bQRBiPsaKyIW8K3Zr99ioHDUgA9OGuGGJPyYpNcffGmBhJfGg==",
+            "version": "5.5.0",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/type-fest/-/type-fest-5.5.0.tgz",
+            "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
             "license": "(MIT OR CC0-1.0)",
             "dependencies": {
                 "tagged-tag": "^1.0.0"
@@ -5706,16 +5591,16 @@
             }
         },
         "node_modules/read-pkg": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-10.0.0.tgz",
-            "integrity": "sha512-A70UlgfNdKI5NSvTTfHzLQj7NJRpJ4mT5tGafkllJ4wh71oYuGm/pzphHcmW4s35iox56KSK721AihodoXSc/A==",
+            "version": "10.1.0",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/read-pkg/-/read-pkg-10.1.0.tgz",
+            "integrity": "sha512-I8g2lArQiP78ll51UeMZojewtYgIRCKCWqZEgOO8c/uefTI+XDXvCSXu3+YNUaTNvZzobrL5+SqHjBrByRRTdg==",
             "license": "MIT",
             "dependencies": {
                 "@types/normalize-package-data": "^2.4.4",
                 "normalize-package-data": "^8.0.0",
                 "parse-json": "^8.3.0",
-                "type-fest": "^5.2.0",
-                "unicorn-magic": "^0.3.0"
+                "type-fest": "^5.4.4",
+                "unicorn-magic": "^0.4.0"
             },
             "engines": {
                 "node": ">=20"
@@ -5726,7 +5611,7 @@
         },
         "node_modules/read-pkg/node_modules/parse-json": {
             "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/parse-json/-/parse-json-8.3.0.tgz",
             "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
             "license": "MIT",
             "dependencies": {
@@ -5743,7 +5628,7 @@
         },
         "node_modules/read-pkg/node_modules/parse-json/node_modules/type-fest": {
             "version": "4.41.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/type-fest/-/type-fest-4.41.0.tgz",
             "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
             "license": "(MIT OR CC0-1.0)",
             "engines": {
@@ -5754,9 +5639,9 @@
             }
         },
         "node_modules/read-pkg/node_modules/type-fest": {
-            "version": "5.4.2",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.2.tgz",
-            "integrity": "sha512-FLEenlVYf7Zcd34ISMLo3ZzRE1gRjY1nMDTp+bQRBiPsaKyIW8K3Zr99ioHDUgA9OGuGGJPyYpNcffGmBhJfGg==",
+            "version": "5.5.0",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/type-fest/-/type-fest-5.5.0.tgz",
+            "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
             "license": "(MIT OR CC0-1.0)",
             "dependencies": {
                 "tagged-tag": "^1.0.0"
@@ -5770,7 +5655,7 @@
         },
         "node_modules/readdirp": {
             "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/readdirp/-/readdirp-4.1.2.tgz",
             "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
             "license": "MIT",
             "engines": {
@@ -5783,13 +5668,13 @@
         },
         "node_modules/reflect-metadata": {
             "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
             "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
             "license": "Apache-2.0"
         },
         "node_modules/regexp-match-indices": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/regexp-match-indices/-/regexp-match-indices-1.0.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/regexp-match-indices/-/regexp-match-indices-1.0.2.tgz",
             "integrity": "sha512-DwZuAkt8NF5mKwGGER1EGh2PRqyvhRhhLviH+R8y8dIuaQROlUfXjt4s9ZTXstIsSkptf06BSvwcEmmfheJJWQ==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -5798,7 +5683,7 @@
         },
         "node_modules/regexp-tree": {
             "version": "0.1.27",
-            "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/regexp-tree/-/regexp-tree-0.1.27.tgz",
             "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
             "license": "MIT",
             "bin": {
@@ -5807,7 +5692,7 @@
         },
         "node_modules/regexp.prototype.flags": {
             "version": "1.5.4",
-            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
             "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
             "license": "MIT",
             "dependencies": {
@@ -5827,7 +5712,7 @@
         },
         "node_modules/repeat-string": {
             "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/repeat-string/-/repeat-string-1.6.1.tgz",
             "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
             "license": "MIT",
             "engines": {
@@ -5836,7 +5721,7 @@
         },
         "node_modules/request-progress": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/request-progress/-/request-progress-3.0.0.tgz",
             "integrity": "sha512-MnWzEHHaxHO2iWiQuHrUPBi/1WeBf5PkxQqNyNvLl9VAYSdXkP8tQ3pBSeCPD+yw0v0Aq1zosWLz0BdeXpWwZg==",
             "license": "MIT",
             "dependencies": {
@@ -5845,7 +5730,7 @@
         },
         "node_modules/require-and-forget": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/require-and-forget/-/require-and-forget-1.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/require-and-forget/-/require-and-forget-1.0.1.tgz",
             "integrity": "sha512-Sea861D/seGo3cptxc857a34Df0oEijXit8Q3IDodiwZMzVmyXrRI9EgQQa3hjkhoEjNzCBvv0t/0fMgebmWLg==",
             "license": "MIT",
             "dependencies": {
@@ -5857,7 +5742,7 @@
         },
         "node_modules/require-and-forget/node_modules/debug": {
             "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/debug/-/debug-4.3.4.tgz",
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "license": "MIT",
             "dependencies": {
@@ -5874,13 +5759,13 @@
         },
         "node_modules/require-and-forget/node_modules/ms": {
             "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "license": "MIT"
         },
         "node_modules/require-directory": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
             "license": "MIT",
             "engines": {
@@ -5889,7 +5774,7 @@
         },
         "node_modules/requirejs": {
             "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.8.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/requirejs/-/requirejs-2.3.8.tgz",
             "integrity": "sha512-7/cTSLOdYkNBNJcDMWf+luFvMriVm7eYxp4BcFCsAX0wF421Vyce5SXP17c+Jd5otXKGNehIonFlyQXSowL6Mw==",
             "license": "MIT",
             "bin": {
@@ -5902,7 +5787,7 @@
         },
         "node_modules/requirejs-config-file": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/requirejs-config-file/-/requirejs-config-file-4.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/requirejs-config-file/-/requirejs-config-file-4.0.0.tgz",
             "integrity": "sha512-jnIre8cbWOyvr8a5F2KuqBnY+SDA4NXr/hzEZJG79Mxm2WiFQz2dzhC8ibtPJS7zkmBEl1mxSwp5HhC1W4qpxw==",
             "license": "MIT",
             "dependencies": {
@@ -5915,7 +5800,7 @@
         },
         "node_modules/resolve": {
             "version": "1.22.11",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/resolve/-/resolve-1.22.11.tgz",
             "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
             "license": "MIT",
             "dependencies": {
@@ -5935,7 +5820,7 @@
         },
         "node_modules/resolve-dependency-path": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/resolve-dependency-path/-/resolve-dependency-path-4.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/resolve-dependency-path/-/resolve-dependency-path-4.0.1.tgz",
             "integrity": "sha512-YQftIIC4vzO9UMhO/sCgXukNyiwVRCVaxiWskCBy7Zpqkplm8kTAISZ8O1MoKW1ca6xzgLUBjZTcDgypXvXxiQ==",
             "license": "MIT",
             "engines": {
@@ -5944,7 +5829,7 @@
         },
         "node_modules/resolve-from": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/resolve-from/-/resolve-from-4.0.0.tgz",
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
             "license": "MIT",
             "engines": {
@@ -5953,7 +5838,7 @@
         },
         "node_modules/resolve-pkg-maps": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
             "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
             "license": "MIT",
             "funding": {
@@ -5962,7 +5847,7 @@
         },
         "node_modules/restore-cursor": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/restore-cursor/-/restore-cursor-3.1.0.tgz",
             "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
             "license": "MIT",
             "dependencies": {
@@ -5975,7 +5860,7 @@
         },
         "node_modules/reusify": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/reusify/-/reusify-1.1.0.tgz",
             "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
             "license": "MIT",
             "engines": {
@@ -5985,13 +5870,13 @@
         },
         "node_modules/rfdc": {
             "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/rfdc/-/rfdc-1.4.1.tgz",
             "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
             "license": "MIT"
         },
         "node_modules/run-parallel": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/run-parallel/-/run-parallel-1.2.0.tgz",
             "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
             "funding": [
                 {
@@ -6014,7 +5899,7 @@
         },
         "node_modules/rxjs": {
             "version": "7.8.2",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/rxjs/-/rxjs-7.8.2.tgz",
             "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -6023,7 +5908,7 @@
         },
         "node_modules/safe-buffer": {
             "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
             "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
             "funding": [
                 {
@@ -6043,7 +5928,7 @@
         },
         "node_modules/safe-regex-test": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
             "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
             "license": "MIT",
             "dependencies": {
@@ -6060,18 +5945,18 @@
         },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "license": "MIT"
         },
         "node_modules/sass-lookup": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/sass-lookup/-/sass-lookup-6.1.0.tgz",
-            "integrity": "sha512-Zx+lVyoWqXZxHuYWlTA17Z5sczJ6braNT2C7rmClw+c4E7r/n911Zwss3h1uHI9reR5AgHZyNHF7c2+VIp5AUA==",
+            "version": "6.1.1",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/sass-lookup/-/sass-lookup-6.1.1.tgz",
+            "integrity": "sha512-12dvZdQYTeKZ1ypjuiijZYuMZ1m0F+4+BkRX5yJi2WA9W3DBUrcdCt7bVuKlagHl11n8eYtalWDle+m98Ol2DA==",
             "license": "MIT",
             "dependencies": {
                 "commander": "^12.1.0",
-                "enhanced-resolve": "^5.18.0"
+                "enhanced-resolve": "^5.20.0"
             },
             "bin": {
                 "sass-lookup": "bin/cli.js"
@@ -6082,7 +5967,7 @@
         },
         "node_modules/sass-lookup/node_modules/commander": {
             "version": "12.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/commander/-/commander-12.1.0.tgz",
             "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
             "license": "MIT",
             "engines": {
@@ -6091,20 +5976,20 @@
         },
         "node_modules/seed-random": {
             "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/seed-random/-/seed-random-2.2.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/seed-random/-/seed-random-2.2.0.tgz",
             "integrity": "sha512-34EQV6AAHQGhoc0tn/96a9Fsi6v2xdqe/dMUwljGRaFOzR3EgRmECvD0O8vi8X+/uQ50LGHfkNu/Eue5TPKZkQ==",
             "license": "MIT"
         },
         "node_modules/seedrandom": {
             "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/seedrandom/-/seedrandom-3.0.5.tgz",
             "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
             "license": "MIT"
         },
         "node_modules/semver": {
-            "version": "7.7.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-            "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+            "version": "7.7.4",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -6115,7 +6000,7 @@
         },
         "node_modules/serialize-javascript": {
             "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
             "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -6124,7 +6009,7 @@
         },
         "node_modules/set-function-length": {
             "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/set-function-length/-/set-function-length-1.2.2.tgz",
             "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
             "license": "MIT",
             "dependencies": {
@@ -6141,7 +6026,7 @@
         },
         "node_modules/set-function-name": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/set-function-name/-/set-function-name-2.0.2.tgz",
             "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
             "license": "MIT",
             "dependencies": {
@@ -6156,7 +6041,7 @@
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
             "license": "MIT",
             "dependencies": {
@@ -6168,7 +6053,7 @@
         },
         "node_modules/shebang-regex": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "license": "MIT",
             "engines": {
@@ -6177,7 +6062,7 @@
         },
         "node_modules/shelljs": {
             "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.10.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/shelljs/-/shelljs-0.10.0.tgz",
             "integrity": "sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==",
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -6190,7 +6075,7 @@
         },
         "node_modules/shelljs/node_modules/execa": {
             "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/execa/-/execa-5.1.1.tgz",
             "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
             "license": "MIT",
             "dependencies": {
@@ -6213,7 +6098,7 @@
         },
         "node_modules/shelljs/node_modules/get-stream": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/get-stream/-/get-stream-6.0.1.tgz",
             "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
             "license": "MIT",
             "engines": {
@@ -6225,7 +6110,7 @@
         },
         "node_modules/shelljs/node_modules/human-signals": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/human-signals/-/human-signals-2.1.0.tgz",
             "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
             "license": "Apache-2.0",
             "engines": {
@@ -6234,7 +6119,7 @@
         },
         "node_modules/side-channel": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/side-channel/-/side-channel-1.1.0.tgz",
             "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
             "license": "MIT",
             "dependencies": {
@@ -6253,7 +6138,7 @@
         },
         "node_modules/side-channel-list": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/side-channel-list/-/side-channel-list-1.0.0.tgz",
             "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
             "license": "MIT",
             "dependencies": {
@@ -6269,7 +6154,7 @@
         },
         "node_modules/side-channel-map": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/side-channel-map/-/side-channel-map-1.0.1.tgz",
             "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
             "license": "MIT",
             "dependencies": {
@@ -6287,7 +6172,7 @@
         },
         "node_modules/side-channel-weakmap": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
             "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
             "license": "MIT",
             "dependencies": {
@@ -6306,13 +6191,13 @@
         },
         "node_modules/signal-exit": {
             "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/signal-exit/-/signal-exit-3.0.7.tgz",
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
             "license": "ISC"
         },
         "node_modules/simple-bin-help": {
             "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/simple-bin-help/-/simple-bin-help-1.8.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/simple-bin-help/-/simple-bin-help-1.8.0.tgz",
             "integrity": "sha512-0LxHn+P1lF5r2WwVB/za3hLRIsYoLaNq1CXqjbrs3ZvLuvlWnRKrUjEWzV7umZL7hpQ7xULiQMV+0iXdRa5iFg==",
             "license": "MIT",
             "engines": {
@@ -6321,7 +6206,7 @@
         },
         "node_modules/slice-ansi": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/slice-ansi/-/slice-ansi-3.0.0.tgz",
             "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
             "license": "MIT",
             "dependencies": {
@@ -6333,24 +6218,9 @@
                 "node": ">=8"
             }
         },
-        "node_modules/slice-ansi/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "license": "MIT",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
         "node_modules/source-map": {
             "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "license": "BSD-3-Clause",
             "engines": {
@@ -6359,7 +6229,7 @@
         },
         "node_modules/source-map-js": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/source-map-js/-/source-map-js-1.2.1.tgz",
             "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
             "license": "BSD-3-Clause",
             "engines": {
@@ -6368,7 +6238,7 @@
         },
         "node_modules/source-map-support": {
             "version": "0.5.21",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/source-map-support/-/source-map-support-0.5.21.tgz",
             "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
             "license": "MIT",
             "dependencies": {
@@ -6378,7 +6248,7 @@
         },
         "node_modules/spdx-correct": {
             "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/spdx-correct/-/spdx-correct-3.2.0.tgz",
             "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -6388,13 +6258,13 @@
         },
         "node_modules/spdx-exceptions": {
             "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
             "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
             "license": "CC-BY-3.0"
         },
         "node_modules/spdx-expression-parse": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
             "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
             "license": "MIT",
             "dependencies": {
@@ -6403,21 +6273,21 @@
             }
         },
         "node_modules/spdx-license-ids": {
-            "version": "3.0.22",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
-            "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
+            "version": "3.0.23",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+            "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
             "license": "CC0-1.0"
         },
         "node_modules/spec-change": {
-            "version": "1.11.20",
-            "resolved": "https://registry.npmjs.org/spec-change/-/spec-change-1.11.20.tgz",
-            "integrity": "sha512-N9V0tptwsYs6WRvO3CYdHaptwj+EAaTAktTwIx9cEKkdboX4BBWY5//EhV9EoOzpGYO/4zHhs6lY3dHQPcMB6g==",
+            "version": "1.11.21",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/spec-change/-/spec-change-1.11.21.tgz",
+            "integrity": "sha512-87FZBOBjTyXF/R8juve+lHp+Q+9UlcwCF4rEM995jPGrJBYAMl19saWc9oRvB36VJqLI66D1FXsXTmetFJtQ9g==",
             "license": "MIT",
             "dependencies": {
                 "arg": "^5.0.2",
                 "debug": "^4.3.4",
                 "deep-equal": "^2.2.3",
-                "dependency-tree": "^11.1.1",
+                "dependency-tree": "^11.4.0",
                 "lazy-ass": "^2.0.3",
                 "tinyglobby": "^0.2.0"
             },
@@ -6427,7 +6297,7 @@
         },
         "node_modules/split": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/split/-/split-1.0.1.tgz",
             "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
             "license": "MIT",
             "dependencies": {
@@ -6439,7 +6309,7 @@
         },
         "node_modules/sshpk": {
             "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/sshpk/-/sshpk-1.18.0.tgz",
             "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
             "license": "MIT",
             "dependencies": {
@@ -6464,13 +6334,13 @@
         },
         "node_modules/stackframe": {
             "version": "1.3.4",
-            "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/stackframe/-/stackframe-1.3.4.tgz",
             "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
             "license": "MIT"
         },
         "node_modules/stop-iteration-iterator": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
             "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
             "license": "MIT",
             "dependencies": {
@@ -6483,7 +6353,7 @@
         },
         "node_modules/string-argv": {
             "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/string-argv/-/string-argv-0.3.1.tgz",
             "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
             "license": "MIT",
             "engines": {
@@ -6492,7 +6362,7 @@
         },
         "node_modules/string-width": {
             "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "license": "MIT",
             "dependencies": {
@@ -6507,7 +6377,7 @@
         "node_modules/string-width-cjs": {
             "name": "string-width",
             "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "license": "MIT",
             "dependencies": {
@@ -6521,7 +6391,7 @@
         },
         "node_modules/stringify-object": {
             "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/stringify-object/-/stringify-object-3.3.0.tgz",
             "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -6535,7 +6405,7 @@
         },
         "node_modules/strip-ansi": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "license": "MIT",
             "dependencies": {
@@ -6548,7 +6418,7 @@
         "node_modules/strip-ansi-cjs": {
             "name": "strip-ansi",
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "license": "MIT",
             "dependencies": {
@@ -6560,7 +6430,7 @@
         },
         "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "license": "MIT",
             "engines": {
@@ -6569,7 +6439,7 @@
         },
         "node_modules/strip-ansi/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "license": "MIT",
             "engines": {
@@ -6578,7 +6448,7 @@
         },
         "node_modules/strip-bom": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/strip-bom/-/strip-bom-3.0.0.tgz",
             "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
             "license": "MIT",
             "engines": {
@@ -6587,7 +6457,7 @@
         },
         "node_modules/strip-final-newline": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
             "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
             "license": "MIT",
             "engines": {
@@ -6596,7 +6466,7 @@
         },
         "node_modules/strip-json-comments": {
             "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "license": "MIT",
             "engines": {
@@ -6608,7 +6478,7 @@
         },
         "node_modules/stylus-lookup": {
             "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/stylus-lookup/-/stylus-lookup-6.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/stylus-lookup/-/stylus-lookup-6.1.0.tgz",
             "integrity": "sha512-5QSwgxAzXPMN+yugy61C60PhoANdItfdjSEZR8siFwz7yL9jTmV0UBKDCfn3K8GkGB4g0Y9py7vTCX8rFu4/pQ==",
             "license": "MIT",
             "dependencies": {
@@ -6623,7 +6493,7 @@
         },
         "node_modules/stylus-lookup/node_modules/commander": {
             "version": "12.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/commander/-/commander-12.1.0.tgz",
             "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
             "license": "MIT",
             "engines": {
@@ -6632,7 +6502,7 @@
         },
         "node_modules/supports-color": {
             "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/supports-color/-/supports-color-8.1.1.tgz",
             "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
             "license": "MIT",
             "dependencies": {
@@ -6647,7 +6517,7 @@
         },
         "node_modules/supports-preserve-symlinks-flag": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
             "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
             "license": "MIT",
             "engines": {
@@ -6658,9 +6528,9 @@
             }
         },
         "node_modules/systeminformation": {
-            "version": "5.30.6",
-            "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.30.6.tgz",
-            "integrity": "sha512-LEIyK1aEv5P3BhAPW3swdlIyCihxwEq/Gki+kcONieU4PIeRCSLDuGkk0Va/56PSBgjVgEksOM88dmY6YqOyfQ==",
+            "version": "5.31.5",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/systeminformation/-/systeminformation-5.31.5.tgz",
+            "integrity": "sha512-5SyLdip4/3alxD4Kh+63bUQTJmu7YMfYQTC+koZy7X73HgNqZSD2P4wOZQWtUncvPvcEmnfIjCoygN4MRoEejQ==",
             "license": "MIT",
             "os": [
                 "darwin",
@@ -6685,7 +6555,7 @@
         },
         "node_modules/tagged-tag": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/tagged-tag/-/tagged-tag-1.0.0.tgz",
             "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
             "license": "MIT",
             "engines": {
@@ -6696,9 +6566,9 @@
             }
         },
         "node_modules/tapable": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-            "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+            "version": "2.3.2",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/tapable/-/tapable-2.3.2.tgz",
+            "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -6710,7 +6580,7 @@
         },
         "node_modules/thenify": {
             "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/thenify/-/thenify-3.3.1.tgz",
             "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
             "license": "MIT",
             "dependencies": {
@@ -6719,7 +6589,7 @@
         },
         "node_modules/thenify-all": {
             "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/thenify-all/-/thenify-all-1.6.0.tgz",
             "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
             "license": "MIT",
             "dependencies": {
@@ -6731,7 +6601,7 @@
         },
         "node_modules/throttleit": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/throttleit/-/throttleit-1.0.1.tgz",
             "integrity": "sha512-vDZpf9Chs9mAdfY046mcPt8fg5QSZr37hEH4TXYBnDF+izxgrbRGUAAaBvIk/fJm9aOFCGFd1EsNg5AZCbnQCQ==",
             "license": "MIT",
             "funding": {
@@ -6740,19 +6610,19 @@
         },
         "node_modules/through": {
             "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/through/-/through-2.3.8.tgz",
             "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
             "license": "MIT"
         },
         "node_modules/tiny-case": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/tiny-case/-/tiny-case-1.0.3.tgz",
             "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
             "license": "MIT"
         },
         "node_modules/tinyglobby": {
             "version": "0.2.15",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/tinyglobby/-/tinyglobby-0.2.15.tgz",
             "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
             "license": "MIT",
             "dependencies": {
@@ -6768,7 +6638,7 @@
         },
         "node_modules/tinyglobby/node_modules/fdir": {
             "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/fdir/-/fdir-6.5.0.tgz",
             "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
             "license": "MIT",
             "engines": {
@@ -6784,11 +6654,10 @@
             }
         },
         "node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.4",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -6798,7 +6667,7 @@
         },
         "node_modules/tldts": {
             "version": "6.1.86",
-            "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/tldts/-/tldts-6.1.86.tgz",
             "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
             "license": "MIT",
             "dependencies": {
@@ -6810,13 +6679,13 @@
         },
         "node_modules/tldts-core": {
             "version": "6.1.86",
-            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/tldts-core/-/tldts-core-6.1.86.tgz",
             "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
             "license": "MIT"
         },
         "node_modules/tmp": {
             "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/tmp/-/tmp-0.2.5.tgz",
             "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
             "license": "MIT",
             "engines": {
@@ -6825,7 +6694,7 @@
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
             "license": "MIT",
             "dependencies": {
@@ -6837,13 +6706,13 @@
         },
         "node_modules/toposort": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/toposort/-/toposort-2.0.2.tgz",
             "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
             "license": "MIT"
         },
         "node_modules/tough-cookie": {
             "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/tough-cookie/-/tough-cookie-5.1.2.tgz",
             "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -6855,7 +6724,7 @@
         },
         "node_modules/tree-kill": {
             "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/tree-kill/-/tree-kill-1.2.2.tgz",
             "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
             "license": "MIT",
             "bin": {
@@ -6863,9 +6732,9 @@
             }
         },
         "node_modules/ts-api-utils": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
-            "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+            "version": "2.5.0",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+            "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
             "license": "MIT",
             "engines": {
                 "node": ">=18.12"
@@ -6876,7 +6745,7 @@
         },
         "node_modules/ts-dedent": {
             "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/ts-dedent/-/ts-dedent-2.2.0.tgz",
             "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
             "license": "MIT",
             "engines": {
@@ -6885,7 +6754,7 @@
         },
         "node_modules/tsconfig-paths": {
             "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
             "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
             "license": "MIT",
             "dependencies": {
@@ -6899,13 +6768,13 @@
         },
         "node_modules/tslib": {
             "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "license": "0BSD"
         },
         "node_modules/tsx": {
             "version": "4.21.0",
-            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/tsx/-/tsx-4.21.0.tgz",
             "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
             "license": "MIT",
             "dependencies": {
@@ -6923,9 +6792,9 @@
             }
         },
         "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
-            "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+            "version": "0.27.4",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+            "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
             "cpu": [
                 "ppc64"
             ],
@@ -6939,9 +6808,9 @@
             }
         },
         "node_modules/tsx/node_modules/@esbuild/android-arm": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
-            "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+            "version": "0.27.4",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+            "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
             "cpu": [
                 "arm"
             ],
@@ -6955,9 +6824,9 @@
             }
         },
         "node_modules/tsx/node_modules/@esbuild/android-arm64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
-            "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+            "version": "0.27.4",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+            "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
             "cpu": [
                 "arm64"
             ],
@@ -6971,9 +6840,9 @@
             }
         },
         "node_modules/tsx/node_modules/@esbuild/android-x64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
-            "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+            "version": "0.27.4",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+            "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
             "cpu": [
                 "x64"
             ],
@@ -6987,9 +6856,9 @@
             }
         },
         "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
-            "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+            "version": "0.27.4",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+            "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
             "cpu": [
                 "arm64"
             ],
@@ -7003,9 +6872,9 @@
             }
         },
         "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
-            "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+            "version": "0.27.4",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+            "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
             "cpu": [
                 "x64"
             ],
@@ -7019,9 +6888,9 @@
             }
         },
         "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
-            "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+            "version": "0.27.4",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+            "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
             "cpu": [
                 "arm64"
             ],
@@ -7035,9 +6904,9 @@
             }
         },
         "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
-            "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+            "version": "0.27.4",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+            "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
             "cpu": [
                 "x64"
             ],
@@ -7051,9 +6920,9 @@
             }
         },
         "node_modules/tsx/node_modules/@esbuild/linux-arm": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
-            "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+            "version": "0.27.4",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+            "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
             "cpu": [
                 "arm"
             ],
@@ -7067,9 +6936,9 @@
             }
         },
         "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
-            "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+            "version": "0.27.4",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+            "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
             "cpu": [
                 "arm64"
             ],
@@ -7083,9 +6952,9 @@
             }
         },
         "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
-            "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+            "version": "0.27.4",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+            "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
             "cpu": [
                 "ia32"
             ],
@@ -7099,9 +6968,9 @@
             }
         },
         "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
-            "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+            "version": "0.27.4",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+            "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
             "cpu": [
                 "loong64"
             ],
@@ -7115,9 +6984,9 @@
             }
         },
         "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
-            "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+            "version": "0.27.4",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+            "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
             "cpu": [
                 "mips64el"
             ],
@@ -7131,9 +7000,9 @@
             }
         },
         "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
-            "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+            "version": "0.27.4",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+            "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
             "cpu": [
                 "ppc64"
             ],
@@ -7147,9 +7016,9 @@
             }
         },
         "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
-            "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+            "version": "0.27.4",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+            "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
             "cpu": [
                 "riscv64"
             ],
@@ -7163,9 +7032,9 @@
             }
         },
         "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
-            "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+            "version": "0.27.4",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+            "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
             "cpu": [
                 "s390x"
             ],
@@ -7179,9 +7048,9 @@
             }
         },
         "node_modules/tsx/node_modules/@esbuild/linux-x64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
-            "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+            "version": "0.27.4",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+            "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
             "cpu": [
                 "x64"
             ],
@@ -7195,9 +7064,9 @@
             }
         },
         "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
-            "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+            "version": "0.27.4",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+            "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
             "cpu": [
                 "x64"
             ],
@@ -7211,9 +7080,9 @@
             }
         },
         "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
-            "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+            "version": "0.27.4",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+            "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
             "cpu": [
                 "arm64"
             ],
@@ -7227,9 +7096,9 @@
             }
         },
         "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
-            "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+            "version": "0.27.4",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+            "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
             "cpu": [
                 "x64"
             ],
@@ -7243,9 +7112,9 @@
             }
         },
         "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
-            "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+            "version": "0.27.4",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+            "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
             "cpu": [
                 "x64"
             ],
@@ -7259,9 +7128,9 @@
             }
         },
         "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
-            "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+            "version": "0.27.4",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+            "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
             "cpu": [
                 "arm64"
             ],
@@ -7275,9 +7144,9 @@
             }
         },
         "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
-            "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+            "version": "0.27.4",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+            "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
             "cpu": [
                 "ia32"
             ],
@@ -7291,9 +7160,9 @@
             }
         },
         "node_modules/tsx/node_modules/@esbuild/win32-x64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
-            "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+            "version": "0.27.4",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+            "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
             "cpu": [
                 "x64"
             ],
@@ -7307,9 +7176,9 @@
             }
         },
         "node_modules/tsx/node_modules/esbuild": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
-            "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+            "version": "0.27.4",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/esbuild/-/esbuild-0.27.4.tgz",
+            "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {
@@ -7319,37 +7188,37 @@
                 "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.27.2",
-                "@esbuild/android-arm": "0.27.2",
-                "@esbuild/android-arm64": "0.27.2",
-                "@esbuild/android-x64": "0.27.2",
-                "@esbuild/darwin-arm64": "0.27.2",
-                "@esbuild/darwin-x64": "0.27.2",
-                "@esbuild/freebsd-arm64": "0.27.2",
-                "@esbuild/freebsd-x64": "0.27.2",
-                "@esbuild/linux-arm": "0.27.2",
-                "@esbuild/linux-arm64": "0.27.2",
-                "@esbuild/linux-ia32": "0.27.2",
-                "@esbuild/linux-loong64": "0.27.2",
-                "@esbuild/linux-mips64el": "0.27.2",
-                "@esbuild/linux-ppc64": "0.27.2",
-                "@esbuild/linux-riscv64": "0.27.2",
-                "@esbuild/linux-s390x": "0.27.2",
-                "@esbuild/linux-x64": "0.27.2",
-                "@esbuild/netbsd-arm64": "0.27.2",
-                "@esbuild/netbsd-x64": "0.27.2",
-                "@esbuild/openbsd-arm64": "0.27.2",
-                "@esbuild/openbsd-x64": "0.27.2",
-                "@esbuild/openharmony-arm64": "0.27.2",
-                "@esbuild/sunos-x64": "0.27.2",
-                "@esbuild/win32-arm64": "0.27.2",
-                "@esbuild/win32-ia32": "0.27.2",
-                "@esbuild/win32-x64": "0.27.2"
+                "@esbuild/aix-ppc64": "0.27.4",
+                "@esbuild/android-arm": "0.27.4",
+                "@esbuild/android-arm64": "0.27.4",
+                "@esbuild/android-x64": "0.27.4",
+                "@esbuild/darwin-arm64": "0.27.4",
+                "@esbuild/darwin-x64": "0.27.4",
+                "@esbuild/freebsd-arm64": "0.27.4",
+                "@esbuild/freebsd-x64": "0.27.4",
+                "@esbuild/linux-arm": "0.27.4",
+                "@esbuild/linux-arm64": "0.27.4",
+                "@esbuild/linux-ia32": "0.27.4",
+                "@esbuild/linux-loong64": "0.27.4",
+                "@esbuild/linux-mips64el": "0.27.4",
+                "@esbuild/linux-ppc64": "0.27.4",
+                "@esbuild/linux-riscv64": "0.27.4",
+                "@esbuild/linux-s390x": "0.27.4",
+                "@esbuild/linux-x64": "0.27.4",
+                "@esbuild/netbsd-arm64": "0.27.4",
+                "@esbuild/netbsd-x64": "0.27.4",
+                "@esbuild/openbsd-arm64": "0.27.4",
+                "@esbuild/openbsd-x64": "0.27.4",
+                "@esbuild/openharmony-arm64": "0.27.4",
+                "@esbuild/sunos-x64": "0.27.4",
+                "@esbuild/win32-arm64": "0.27.4",
+                "@esbuild/win32-ia32": "0.27.4",
+                "@esbuild/win32-x64": "0.27.4"
             }
         },
         "node_modules/tunnel": {
             "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/tunnel/-/tunnel-0.0.6.tgz",
             "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
             "license": "MIT",
             "engines": {
@@ -7358,7 +7227,7 @@
         },
         "node_modules/tunnel-agent": {
             "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -7370,13 +7239,13 @@
         },
         "node_modules/tweetnacl": {
             "version": "0.14.5",
-            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/tweetnacl/-/tweetnacl-0.14.5.tgz",
             "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
             "license": "Unlicense"
         },
         "node_modules/type-fest": {
             "version": "4.41.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/type-fest/-/type-fest-4.41.0.tgz",
             "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
             "license": "(MIT OR CC0-1.0)",
             "engines": {
@@ -7388,10 +7257,9 @@
         },
         "node_modules/typescript": {
             "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -7401,28 +7269,28 @@
             }
         },
         "node_modules/undici": {
-            "version": "6.23.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-            "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+            "version": "6.24.1",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/undici/-/undici-6.24.1.tgz",
+            "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
             "license": "MIT",
             "engines": {
                 "node": ">=18.17"
             }
         },
         "node_modules/undici-types": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-            "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+            "version": "7.18.2",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/undici-types/-/undici-types-7.18.2.tgz",
+            "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
             "license": "MIT",
             "optional": true
         },
         "node_modules/unicorn-magic": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
-            "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+            "version": "0.4.0",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+            "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
             "license": "MIT",
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -7430,7 +7298,7 @@
         },
         "node_modules/universalify": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/universalify/-/universalify-2.0.1.tgz",
             "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
             "license": "MIT",
             "engines": {
@@ -7439,7 +7307,7 @@
         },
         "node_modules/untildify": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/untildify/-/untildify-4.0.0.tgz",
             "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
             "license": "MIT",
             "engines": {
@@ -7448,7 +7316,7 @@
         },
         "node_modules/update-browserslist-db": {
             "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
             "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
             "funding": [
                 {
@@ -7465,6 +7333,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "escalade": "^3.2.0",
                 "picocolors": "^1.1.1"
@@ -7478,7 +7347,7 @@
         },
         "node_modules/upper-case-first": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/upper-case-first/-/upper-case-first-2.0.2.tgz",
             "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
             "license": "MIT",
             "dependencies": {
@@ -7487,13 +7356,13 @@
         },
         "node_modules/util-arity": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/util-arity/-/util-arity-1.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/util-arity/-/util-arity-1.1.0.tgz",
             "integrity": "sha512-kkyIsXKwemfSy8ZEoaIz06ApApnWsk5hQO0vLjZS6UkBiGiW++Jsyb8vSBoc0WKlffGoGs5yYy/j5pp8zckrFA==",
             "license": "MIT"
         },
         "node_modules/uuid": {
             "version": "13.0.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/uuid/-/uuid-13.0.0.tgz",
             "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
             "funding": [
                 "https://github.com/sponsors/broofa",
@@ -7506,7 +7375,7 @@
         },
         "node_modules/validate-npm-package-license": {
             "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
             "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -7516,7 +7385,7 @@
         },
         "node_modules/verror": {
             "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/verror/-/verror-1.10.0.tgz",
             "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
             "engines": [
                 "node >=0.6.0"
@@ -7530,7 +7399,7 @@
         },
         "node_modules/wcwidth": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/wcwidth/-/wcwidth-1.0.1.tgz",
             "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
             "license": "MIT",
             "optional": true,
@@ -7540,7 +7409,7 @@
         },
         "node_modules/which": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "license": "ISC",
             "dependencies": {
@@ -7555,7 +7424,7 @@
         },
         "node_modules/which-boxed-primitive": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
             "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
             "license": "MIT",
             "dependencies": {
@@ -7574,7 +7443,7 @@
         },
         "node_modules/which-collection": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/which-collection/-/which-collection-1.0.2.tgz",
             "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
             "license": "MIT",
             "dependencies": {
@@ -7592,7 +7461,7 @@
         },
         "node_modules/which-typed-array": {
             "version": "1.1.20",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/which-typed-array/-/which-typed-array-1.1.20.tgz",
             "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
             "license": "MIT",
             "dependencies": {
@@ -7613,13 +7482,13 @@
         },
         "node_modules/workerpool": {
             "version": "9.3.4",
-            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/workerpool/-/workerpool-9.3.4.tgz",
             "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
             "license": "Apache-2.0"
         },
         "node_modules/wrap-ansi": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
             "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
             "license": "MIT",
             "dependencies": {
@@ -7637,7 +7506,7 @@
         "node_modules/wrap-ansi-cjs": {
             "name": "wrap-ansi",
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
             "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
             "license": "MIT",
             "dependencies": {
@@ -7652,45 +7521,15 @@
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
-        "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "license": "MIT",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/wrap-ansi/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "license": "MIT",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
         "node_modules/wrappy": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "license": "ISC"
         },
         "node_modules/xmlbuilder": {
             "version": "15.1.1",
-            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
             "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
             "license": "MIT",
             "engines": {
@@ -7699,7 +7538,7 @@
         },
         "node_modules/y18n": {
             "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/y18n/-/y18n-5.0.8.tgz",
             "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
             "license": "ISC",
             "engines": {
@@ -7708,14 +7547,15 @@
         },
         "node_modules/yallist": {
             "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/yallist/-/yallist-3.1.1.tgz",
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-            "license": "ISC"
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/yaml": {
-            "version": "2.8.2",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-            "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+            "version": "2.8.3",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/yaml/-/yaml-2.8.3.tgz",
+            "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
             "license": "ISC",
             "bin": {
                 "yaml": "bin.mjs"
@@ -7729,7 +7569,7 @@
         },
         "node_modules/yargs": {
             "version": "17.7.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/yargs/-/yargs-17.7.2.tgz",
             "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
             "license": "MIT",
             "dependencies": {
@@ -7747,7 +7587,7 @@
         },
         "node_modules/yargs-parser": {
             "version": "21.1.1",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/yargs-parser/-/yargs-parser-21.1.1.tgz",
             "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
             "license": "ISC",
             "engines": {
@@ -7756,7 +7596,7 @@
         },
         "node_modules/yargs-unparser": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
             "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
             "license": "MIT",
             "dependencies": {
@@ -7771,7 +7611,7 @@
         },
         "node_modules/yauzl": {
             "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/yauzl/-/yauzl-2.10.0.tgz",
             "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
             "license": "MIT",
             "dependencies": {
@@ -7781,7 +7621,7 @@
         },
         "node_modules/yocto-queue": {
             "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/yocto-queue/-/yocto-queue-0.1.0.tgz",
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
             "license": "MIT",
             "engines": {
@@ -7793,7 +7633,7 @@
         },
         "node_modules/yup": {
             "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/yup/-/yup-1.7.1.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/yup/-/yup-1.7.1.tgz",
             "integrity": "sha512-GKHFX2nXul2/4Dtfxhozv701jLQHdf6J34YDh2cEkpqoo8le5Mg6/LrdseVLrFarmFygZTlfIhHx/QKfb/QWXw==",
             "license": "MIT",
             "dependencies": {
@@ -7805,7 +7645,7 @@
         },
         "node_modules/yup/node_modules/type-fest": {
             "version": "2.19.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/type-fest/-/type-fest-2.19.0.tgz",
             "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
             "license": "(MIT OR CC0-1.0)",
             "engines": {

--- a/v1/examples/cucumber/package.json
+++ b/v1/examples/cucumber/package.json
@@ -1,9 +1,9 @@
 {
     "dependencies": {
-        "@badeball/cypress-cucumber-preprocessor": "24.0.0",
+        "@badeball/cypress-cucumber-preprocessor": "24.0.1",
         "@bahmutov/cypress-esbuild-preprocessor": "2.2.3",
         "@shelex/cypress-allure-plugin": "^2.40.2",
-        "cypress": "15.9.0",
+        "cypress": "15.12.0",
         "esbuild": "0.24.0"
     }
 }

--- a/v1/examples/cypress-grep/.sauce/config.yml
+++ b/v1/examples/cypress-grep/.sauce/config.yml
@@ -9,7 +9,7 @@ sauce:
       - cypress-grep-example
     build: Github Run $GITHUB_RUN_ID
 cypress:
-  version: 15.9.0
+  version: 15.12.0
   configFile: "cypress.config.js"
 rootDir: ./
 suites:

--- a/v1/examples/multi-reporter/.sauce/config.yml
+++ b/v1/examples/multi-reporter/.sauce/config.yml
@@ -11,7 +11,7 @@ sauce:
     build: Github Run $GITHUB_RUN_ID
 
 cypress:
-  version: 15.9.0
+  version: 15.12.0
   configFile: "cypress.config.js"
 npm:
   usePackageLock: true

--- a/v1/examples/multi-reporter/package-lock.json
+++ b/v1/examples/multi-reporter/package-lock.json
@@ -5,7 +5,7 @@
     "packages": {
         "": {
             "devDependencies": {
-                "cypress": "15.9.0",
+                "cypress": "15.12.0",
                 "cypress-multi-reporters": "^2.0.5",
                 "mocha-junit-reporter": "^2.2.1",
                 "mochawesome": "^7.1.3"
@@ -68,6 +68,7 @@
             "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "string-width": "^5.1.2",
                 "string-width-cjs": "npm:string-width@^4.2.0",
@@ -86,6 +87,7 @@
             "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -99,6 +101,7 @@
             "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -111,7 +114,8 @@
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
             "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@isaacs/cliui/node_modules/string-width": {
             "version": "5.1.2",
@@ -119,6 +123,7 @@
             "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "eastasianwidth": "^0.2.0",
                 "emoji-regex": "^9.2.2",
@@ -137,6 +142,7 @@
             "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-regex": "^6.0.1"
             },
@@ -153,6 +159,7 @@
             "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-styles": "^6.1.0",
                 "string-width": "^5.0.1",
@@ -172,6 +179,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=14"
             }
@@ -324,7 +332,8 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true,
-            "license": "Python-2.0"
+            "license": "Python-2.0",
+            "peer": true
         },
         "node_modules/asn1": {
             "version": "0.2.6",
@@ -395,7 +404,8 @@
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/base64-js": {
             "version": "1.5.1",
@@ -448,6 +458,7 @@
             "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "balanced-match": "^1.0.0"
             }
@@ -457,7 +468,8 @@
             "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
             "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
             "dev": true,
-            "license": "ISC"
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/buffer": {
             "version": "5.7.1",
@@ -541,6 +553,7 @@
             "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -601,6 +614,7 @@
             "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "readdirp": "^4.0.1"
             },
@@ -802,9 +816,9 @@
             }
         },
         "node_modules/cypress": {
-            "version": "15.9.0",
-            "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.9.0.tgz",
-            "integrity": "sha512-Ks6Bdilz3TtkLZtTQyqYaqtL/WT3X3APKaSLhTV96TmTyudzSjc6EJsJCHmBb7DxO+3R12q3Jkbjgm/iPgmwfg==",
+            "version": "15.12.0",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/cypress/-/cypress-15.12.0.tgz",
+            "integrity": "sha512-B2BRcudLfA4NZZP5QpA45J70bu1heCH59V1yKRLHAtiC49r7RV03X5ifUh7Nfbk8QNg93RAsc6oAmodm/+j0pA==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -837,7 +851,7 @@
                 "hasha": "5.2.2",
                 "is-installed-globally": "~0.4.0",
                 "listr2": "^3.8.3",
-                "lodash": "^4.17.21",
+                "lodash": "^4.17.23",
                 "log-symbols": "^4.0.0",
                 "minimist": "^1.2.8",
                 "ospath": "^1.2.2",
@@ -846,9 +860,10 @@
                 "proxy-from-env": "1.0.0",
                 "request-progress": "^3.0.0",
                 "supports-color": "^8.1.1",
-                "systeminformation": "^5.27.14",
+                "systeminformation": "^5.31.1",
                 "tmp": "~0.2.4",
                 "tree-kill": "1.2.2",
+                "tslib": "1.14.1",
                 "untildify": "^4.0.0",
                 "yauzl": "^2.10.0"
             },
@@ -876,6 +891,13 @@
             "peerDependencies": {
                 "mocha": ">=3.1.2"
             }
+        },
+        "node_modules/cypress/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true,
+            "license": "0BSD"
         },
         "node_modules/dashdash": {
             "version": "1.14.1",
@@ -931,6 +953,7 @@
             "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -954,6 +977,7 @@
             "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
             "dev": true,
             "license": "BSD-3-Clause",
+            "peer": true,
             "engines": {
                 "node": ">=0.3.1"
             }
@@ -978,7 +1002,8 @@
             "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
             "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/ecc-jsbn": {
             "version": "0.1.2",
@@ -1014,7 +1039,6 @@
             "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-colors": "^4.1.1",
                 "strip-ansi": "^6.0.1"
@@ -1213,6 +1237,7 @@
             "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "locate-path": "^6.0.0",
                 "path-exists": "^4.0.0"
@@ -1230,6 +1255,7 @@
             "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
             "dev": true,
             "license": "BSD-3-Clause",
+            "peer": true,
             "bin": {
                 "flat": "cli.js"
             }
@@ -1240,6 +1266,7 @@
             "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "cross-spawn": "^7.0.6",
                 "signal-exit": "^4.0.1"
@@ -1257,6 +1284,7 @@
             "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": ">=14"
             },
@@ -1405,6 +1433,7 @@
             "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "foreground-child": "^3.1.0",
                 "jackspeak": "^3.1.2",
@@ -1531,6 +1560,7 @@
             "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "he": "bin/he"
             }
@@ -1651,6 +1681,7 @@
             "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -1708,6 +1739,7 @@
             "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
             "dev": true,
             "license": "BlueOak-1.0.0",
+            "peer": true,
             "dependencies": {
                 "@isaacs/cliui": "^8.0.2"
             },
@@ -1731,6 +1763,7 @@
             "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -1822,6 +1855,7 @@
             "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "p-locate": "^5.0.0"
             },
@@ -1961,7 +1995,8 @@
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
             "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
             "dev": true,
-            "license": "ISC"
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
@@ -2031,6 +2066,7 @@
             "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "brace-expansion": "^2.0.1"
             },
@@ -2057,6 +2093,7 @@
             "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": ">=16 || 14 >=14.17"
             }
@@ -2138,6 +2175,7 @@
             "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -2307,6 +2345,7 @@
             "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "yocto-queue": "^0.1.0"
             },
@@ -2323,6 +2362,7 @@
             "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "p-limit": "^3.0.2"
             },
@@ -2354,7 +2394,8 @@
             "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
             "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
             "dev": true,
-            "license": "BlueOak-1.0.0"
+            "license": "BlueOak-1.0.0",
+            "peer": true
         },
         "node_modules/path-exists": {
             "version": "4.0.0",
@@ -2362,6 +2403,7 @@
             "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -2382,6 +2424,7 @@
             "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
             "dev": true,
             "license": "BlueOak-1.0.0",
+            "peer": true,
             "dependencies": {
                 "lru-cache": "^10.2.0",
                 "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -2412,7 +2455,8 @@
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
             "dev": true,
-            "license": "ISC"
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/pify": {
             "version": "2.3.0",
@@ -2499,6 +2543,7 @@
             "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "safe-buffer": "^5.1.0"
             }
@@ -2516,6 +2561,7 @@
             "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 14.18.0"
             },
@@ -2622,6 +2668,7 @@
             "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
             "dev": true,
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "randombytes": "^2.1.0"
             }
@@ -2795,6 +2842,7 @@
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -2824,6 +2872,7 @@
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -2847,6 +2896,7 @@
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             },
@@ -2871,9 +2921,9 @@
             }
         },
         "node_modules/systeminformation": {
-            "version": "5.30.6",
-            "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.30.6.tgz",
-            "integrity": "sha512-LEIyK1aEv5P3BhAPW3swdlIyCihxwEq/Gki+kcONieU4PIeRCSLDuGkk0Va/56PSBgjVgEksOM88dmY6YqOyfQ==",
+            "version": "5.31.5",
+            "resolved": "https://artifactory.tools.saucelabs.net:443/artifactory/api/npm/all-npm/systeminformation/-/systeminformation-5.31.5.tgz",
+            "integrity": "sha512-5SyLdip4/3alxD4Kh+63bUQTJmu7YMfYQTC+koZy7X73HgNqZSD2P4wOZQWtUncvPvcEmnfIjCoygN4MRoEejQ==",
             "dev": true,
             "license": "MIT",
             "os": [
@@ -3095,7 +3145,8 @@
             "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
             "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
             "dev": true,
-            "license": "Apache-2.0"
+            "license": "Apache-2.0",
+            "peer": true
         },
         "node_modules/wrap-ansi": {
             "version": "7.0.0",
@@ -3122,6 +3173,7 @@
             "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-styles": "^4.0.0",
                 "string-width": "^4.1.0",
@@ -3193,6 +3245,7 @@
             "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "camelcase": "^6.0.0",
                 "decamelize": "^4.0.0",
@@ -3220,6 +3273,7 @@
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },

--- a/v1/examples/multi-reporter/package.json
+++ b/v1/examples/multi-reporter/package.json
@@ -1,6 +1,6 @@
 {
     "devDependencies": {
-        "cypress": "15.9.0",
+        "cypress": "15.12.0",
         "cypress-multi-reporters": "^2.0.5",
         "mocha-junit-reporter": "^2.2.1",
         "mochawesome": "^7.1.3"

--- a/v1/examples/typescript/.sauce/config.yml
+++ b/v1/examples/typescript/.sauce/config.yml
@@ -10,7 +10,7 @@ sauce:
       - other tag
     build: Github Run $GITHUB_RUN_ID
 cypress:
-  version: 15.9.0 # See https://docs.saucelabs.com/web-apps/automated-testing/cypress/#supported-testing-platforms for a list of supported versions.
+  version: 15.12.0 # See https://docs.saucelabs.com/web-apps/automated-testing/cypress/#supported-testing-platforms for a list of supported versions.
   configFile: "cypress.config.js"
 # Controls what files are available in the context of a test run (unless explicitly excluded by .sauceignore).
 rootDir: ./

--- a/v1/examples/webkit/.sauce/config.yml
+++ b/v1/examples/webkit/.sauce/config.yml
@@ -9,7 +9,7 @@ sauce:
       - cypress-example
 
 cypress:
-  version: 15.9.0
+  version: 15.12.0
   configFile: "cypress.config.js"
 
 rootDir: ./


### PR DESCRIPTION
## Description
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->
## Summary
- Update cypress from 15.9.0 to 15.12.0 across all example configs and package.json files
- Update @badeball/cypress-cucumber-preprocessor from 24.0.0 to 24.0.1 in the cucumber example
- Regenerate package-lock.json files

Aligns with sauce-cypress-runner update: https://github.com/saucelabs/sauce-cypress-runner/pull/349