### PR TITLE
Add a macOS 14 cypress example suite

### DIFF
--- a/v1/.sauce/config.yml
+++ b/v1/.sauce/config.yml
@@ -10,7 +10,7 @@ sauce:
       - other tag
     build: Github Run $GITHUB_RUN_ID
 cypress:
-  version: 15.9.0 # See https://docs.saucelabs.com/web-apps/automated-testing/cypress/#supported-testing-platforms for a list of supported versions.
+  version: 15.14.2 # See https://docs.saucelabs.com/web-apps/automated-testing/cypress/#supported-testing-platforms for a list of supported versions.
   configFile: "cypress.config.js"
 
 # Controls what files are available in the context of a test run (unless explicitly excluded by .sauceignore).
@@ -28,6 +28,12 @@ suites:
     browserVersion: "latest"
     shard: spec
     platformName: "macOS 13"
+    config:
+      specPattern: ["cypress/e2e/**/*.*"]
+  - name: "Chrome on macOS 14 (Apple Silicon)"
+    browser: "chrome"
+    shard: spec
+    platformName: "macOS 14"
     config:
       specPattern: ["cypress/e2e/**/*.*"]
 


### PR DESCRIPTION
What this does

This bumps the example cypress version to 15.14.2 and adds a chrome suite on macOS 14 Apple Silicon.

Why

This is part of INT-246. The example repo shows customers how to run cypress on macOS 14.

Do not merge yet

Keep this as a draft until cypress on macOS 14 is live so the example works when customers copy it.
