### PR TITLE
Add macOS 14 and 15 Apple Silicon Cypress example suites

### DIFF
--- a/v1/.sauce/config.yml
+++ b/v1/.sauce/config.yml
@@ -30,6 +30,18 @@ suites:
     platformName: "macOS 13"
     config:
       specPattern: ["cypress/e2e/**/*.*"]
+  - name: "Chrome on macOS 14 (Apple Silicon)"
+    browser: "chrome"
+    shard: spec
+    platformName: "macOS 14"
+    config:
+      specPattern: ["cypress/e2e/**/*.*"]
+  - name: "Webkit on macOS 14 (Apple Silicon)"
+    browser: "webkit"
+    shard: spec
+    platformName: "macOS 14"
+    config:
+      specPattern: ["cypress/e2e/**/*.*"]
   - name: "Chrome on macOS 15 (Apple Silicon)"
     browser: "chrome"
     shard: spec

--- a/v1/.sauce/config.yml
+++ b/v1/.sauce/config.yml
@@ -10,7 +10,7 @@ sauce:
       - other tag
     build: Github Run $GITHUB_RUN_ID
 cypress:
-  version: 15.9.0 # See https://docs.saucelabs.com/web-apps/automated-testing/cypress/#supported-testing-platforms for a list of supported versions.
+  version: 15.14.2 # See https://docs.saucelabs.com/web-apps/automated-testing/cypress/#supported-testing-platforms for a list of supported versions.
   configFile: "cypress.config.js"
 
 # Controls what files are available in the context of a test run (unless explicitly excluded by .sauceignore).
@@ -28,6 +28,18 @@ suites:
     browserVersion: "latest"
     shard: spec
     platformName: "macOS 13"
+    config:
+      specPattern: ["cypress/e2e/**/*.*"]
+  - name: "Chrome on macOS 15 (Apple Silicon)"
+    browser: "chrome"
+    shard: spec
+    platformName: "macOS 15"
+    config:
+      specPattern: ["cypress/e2e/**/*.*"]
+  - name: "Webkit on macOS 15 (Apple Silicon)"
+    browser: "webkit"
+    shard: spec
+    platformName: "macOS 15"
     config:
       specPattern: ["cypress/e2e/**/*.*"]
 

--- a/v1/cypress.config.js
+++ b/v1/cypress.config.js
@@ -1,6 +1,7 @@
 const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
+  experimentalWebKitSupport: true,
   e2e: {
   },
 })


### PR DESCRIPTION
Adds Cypress example suites for macOS 14 and macOS 15 on Apple Silicon and bumps the example to cypress 15.14.2 with experimentalWebKitSupport, continuing the INT-246 work.

Changes to v1/.sauce/config.yml and v1/cypress.config.js:
- Bump cypress 15.9.0 to 15.14.2.
- Add Chrome and WebKit suites on macOS 14 (Apple Silicon).
- Add Chrome and WebKit suites on macOS 15 (Apple Silicon).
- Enable experimentalWebKitSupport so the WebKit suites can launch.

Notes for reviewers:
- Supersedes #132 (macOS 14 example): this PR now carries the macOS 14 suites plus macOS 15, so #132 can be closed as superseded.
- macOS 15 correctly has no Firefox suite (macOS firewall issue). macOS 14 supports all browsers, and Chrome plus WebKit are exercised here.
- No saucectl pin: CI uses saucelabs/saucectl-run-action at latest.
