### PR TITLE
example: add WebKit on macOS 26 (Apple Silicon) suite

### DIFF
--- a/v1/.sauce/config.yml
+++ b/v1/.sauce/config.yml
@@ -54,6 +54,18 @@ suites:
     platformName: "macOS 15"
     config:
       specPattern: ["cypress/e2e/**/*.*"]
+  - name: "Chrome on macOS 26 (Apple Silicon)"
+    browser: "chrome"
+    shard: spec
+    platformName: "macOS 26"
+    config:
+      specPattern: ["cypress/e2e/**/*.*"]
+  - name: "Webkit on macOS 26 (Apple Silicon)"
+    browser: "webkit"
+    shard: spec
+    platformName: "macOS 26"
+    config:
+      specPattern: ["cypress/e2e/**/*.*"]
 
 # Controls what artifacts to fetch when the suites have finished.
 artifacts:


### PR DESCRIPTION
## What
Add a **WebKit on macOS 26 (Apple Silicon)** suite to the v1 example (part of INT-246 Cypress macOS 26 enablement).

- `v1/.sauce/config.yml`: new suite targeting `platformName: "macOS 26"` with `browser: webkit`. macOS 14/15/26 are Apple Silicon; Cypress routes there via `platformName` (no `armRequired`).
- `v1/cypress.config.js`: set `experimentalWebKitSupport: true` (Cypress requires it to launch WebKit).

## Why draft
Holding until Cypress macOS 26 is GA. macOS 14+ requires a Premium plan.
